### PR TITLE
Add support for mimic joints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,38 @@ include:
 </ros2_control>
 ```
 
+
+### Using mimic joints in simulation
+
+To use `mimic` joints in `ign_ros2_control` you should define its parameters to your URDF.
+We should include:
+
+- `<mimic>` tag to the mimicked joint ([detailed manual(https://wiki.ros.org/urdf/XML/joint))
+- `mimic` and `multiplier` parameters to joint definition in `<ros2_control>` tag
+
+```xml
+<joint name="left_finger_joint" type="prismatic">
+  <mimic joint="right_finger_joint"/>
+  <axis xyz="0 1 0"/>
+  <origin xyz="0.0 0.48 1" rpy="0.0 0.0 3.1415926535"/>
+  <parent link="base"/>
+  <child link="finger_left"/>
+  <limit effort="1000.0" lower="0" upper="0.38" velocity="10"/>
+</joint>
+```
+
+```xml
+<joint name="left_finger_joint">
+  <param name="mimic">right_finger_joint</param>
+  <param name="multiplier">1</param>
+  <command_interface name="position"/>
+  <state_interface name="position"/>
+  <state_interface name="velocity"/>
+  <state_interface name="effort"/>
+</joint>
+```
+
+
 ## Add the ign_ros2_control plugin
 
 In addition to the `ros2_control` tags, a Gazebo plugin needs to be added to your URDF that
@@ -232,4 +264,19 @@ ros2 run ign_ros2_control_demos example_velocity
 ros2 run ign_ros2_control_demos example_effort
 ros2 run ign_ros2_control_demos example_diff_drive
 ros2 run ign_ros2_control_demos example_tricycle_drive
+```
+
+The following example shows parallel gripper with mimic joint:
+
+![](img/gripper.gif)
+
+
+```bash
+ros2 launch ign_ros2_control_demos gripper_mimic_joint_example.launch.py
+```
+
+Send example commands:
+
+```bash
+ros2 run ign_ros2_control_demos example_gripper
 ```

--- a/ign_ros2_control/src/ign_system.cpp
+++ b/ign_ros2_control/src/ign_system.cpp
@@ -28,7 +28,6 @@
 #include <ignition/gazebo/components/JointForce.hh>
 #include <ignition/gazebo/components/JointForceCmd.hh>
 #include <ignition/gazebo/components/JointPosition.hh>
-#include <ignition/gazebo/components/JointPositionReset.hh>
 #include <ignition/gazebo/components/JointVelocity.hh>
 #include <ignition/gazebo/components/JointVelocityCmd.hh>
 #include <ignition/gazebo/components/LinearAcceleration.hh>
@@ -77,6 +76,7 @@ struct MimicJoint
   std::size_t joint_index;
   std::size_t mimicked_joint_index;
   double multiplier = 1.0;
+  std::vector<std::string> interfaces_to_mimic;
 };
 
 class ImuData
@@ -223,10 +223,11 @@ bool IgnitionSystem::initSim(
           return info.name == mimicked_joint;
         });
       if (mimicked_joint_it == hardware_info.joints.end()) {
-        throw std::runtime_error(
-                std::string("Mimicked joint '") + mimicked_joint + "' not found");
+          throw std::runtime_error(
+                  std::string("Mimicked joint '") + mimicked_joint + "' not found");
       }
-      MimicJoint mimic_joint;
+
+        MimicJoint mimic_joint;
       mimic_joint.joint_index = j;
       mimic_joint.mimicked_joint_index = std::distance(
         hardware_info.joints.begin(), mimicked_joint_it);
@@ -236,12 +237,32 @@ bool IgnitionSystem::initSim(
       } else {
         mimic_joint.multiplier = 1.0;
       }
-      RCLCPP_INFO_STREAM(
+
+      // check joint info of mimicked joint
+      auto & joint_info_mimicked = hardware_info.joints[mimic_joint.mimicked_joint_index];
+      const auto state_mimicked_interface = std::find_if(joint_info_mimicked.state_interfaces.begin(), joint_info_mimicked.state_interfaces.end(),
+                   [&mimic_joint](const hardware_interface::InterfaceInfo & interface_info) {
+                        bool pos = interface_info.name == "position";
+                        if (pos) mimic_joint.interfaces_to_mimic.push_back(hardware_interface::HW_IF_POSITION);
+                        bool vel =  interface_info.name == "velocity";
+                       if (vel) mimic_joint.interfaces_to_mimic.push_back(hardware_interface::HW_IF_VELOCITY);
+                       bool eff =  interface_info.name == "effort";
+                       if (vel) mimic_joint.interfaces_to_mimic.push_back(hardware_interface::HW_IF_EFFORT);
+                       return pos || vel || eff;
+                   });
+      if (state_mimicked_interface == joint_info_mimicked.state_interfaces.end())
+      {
+          throw std::runtime_error(
+                  std::string("For mimic joint '") + joint_info.name +
+                  "' no state interface was found in mimicked joint '" + mimicked_joint + " ' to mimic");
+      }
+        RCLCPP_INFO_STREAM(
         this->nh_->get_logger(),
         "Joint '" << joint_name << "'is mimicing joint '" << mimicked_joint << "' with mutiplier: "
                   << mimic_joint.multiplier);
       this->dataPtr->mimic_joints_.push_back(mimic_joint);
-      suffix = "_mimic";
+        suffix = "_mimic";
+
     }
 
     RCLCPP_INFO_STREAM(this->nh_->get_logger(), "\tState:");
@@ -602,64 +623,88 @@ hardware_interface::return_type IgnitionSystem::write(
           this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(
           this->dataPtr->joints_[i].sim_joint);
         *jointEffortCmd = ignition::gazebo::components::JointForceCmd(
-          {this->dataPtr->joints_[i].joint_effort_cmd});Ž
+          {this->dataPtr->joints_[i].joint_effort_cmd});
       }
     }
   }
 
   // set values of all mimic joints with respect to mimicked joint
   for (const auto & mimic_joint : this->dataPtr->mimic_joints_) {
-    if (this->dataPtr->joints_[mimic_joint.joint_index].joint_control_method & POSITION &&
-      this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & POSITION)
-    {
-      if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointPositionReset>(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint))
-      {
-        this->dataPtr->ecm->CreateComponent(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
-          ignition::gazebo::components::JointPositionReset(
-            {mimic_joint.multiplier * this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_position}));
-        const auto jointPosCmd =
-          this->dataPtr->ecm->Component<ignition::gazebo::components::JointPositionReset>(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
-        *jointPosCmd = ignition::gazebo::components::JointPositionReset(
-          {mimic_joint.multiplier * this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_position_cmd});
-      }
-    }
-    if (this->dataPtr->joints_[mimic_joint.joint_index].joint_control_method & VELOCITY &&
-      this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & VELOCITY)
-    {
-      if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityCmd>(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint))
-      {
-        this->dataPtr->ecm->CreateComponent(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
-          ignition::gazebo::components::JointVelocityCmd({0}));
-      } else {
-        const auto jointVelCmd =
-          this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityCmd>(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
-        *jointVelCmd = ignition::gazebo::components::JointVelocityCmd(
-          {mimic_joint.multiplier * this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_velocity_cmd});
-      }
-    }
-    if (this->dataPtr->joints_[mimic_joint.joint_index].joint_control_method & EFFORT &&
-      this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & VELOCITY)
-    {
-      if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint))
-      {
-        this->dataPtr->ecm->CreateComponent(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
-          ignition::gazebo::components::JointForceCmd({0}));
-      } else {
-        const auto jointEffortCmd =
-          this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(
-          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
-        *jointEffortCmd = ignition::gazebo::components::JointForceCmd(
-          {mimic_joint.multiplier * this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_effort_cmd});
-      }
-    }
+
+        for (const auto & mimic_interface: mimic_joint.interfaces_to_mimic){
+
+            if (mimic_interface == "position"){
+
+                // Get the joint position
+                double position_mimicked_joint =
+                        this->dataPtr->ecm->Component<ignition::gazebo::components::JointPosition>(
+                                this->dataPtr->joints_[mimic_joint.mimicked_joint_index].sim_joint)->Data()[0];
+
+                double position_mimic_joint =
+                        this->dataPtr->ecm->Component<ignition::gazebo::components::JointPosition>(
+                                this->dataPtr->joints_[mimic_joint.joint_index].sim_joint)->Data()[0];
+
+                double position_error = position_mimic_joint - position_mimicked_joint * mimic_joint.multiplier;
+
+                double velocity_sp = (-1.0) * position_error * (*this->dataPtr->update_rate);
+
+                auto vel =
+                        this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityCmd>(
+                                this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
+
+                if (vel == nullptr) {
+                    this->dataPtr->ecm->CreateComponent(
+                            this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
+                            ignition::gazebo::components::JointVelocityCmd({velocity_sp}));
+                } else if (!vel->Data().empty()) {
+                    vel->Data()[0] = velocity_sp;
+                }
+            }
+            if (mimic_interface == "velocity"){
+
+                // get the velocity of mimicked joint
+                double velocity_mimicked_joint =
+                        this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocity>(
+                                this->dataPtr->joints_[mimic_joint.mimicked_joint_index].sim_joint)->Data()[0];
+
+                if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityCmd>(
+                        this->dataPtr->joints_[mimic_joint.joint_index].sim_joint))
+                {
+                    this->dataPtr->ecm->CreateComponent(
+                            this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
+                            ignition::gazebo::components::JointVelocityCmd({0}));
+                } else {
+                    const auto jointVelCmd =
+                            this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityCmd>(
+                                    this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
+                    *jointVelCmd = ignition::gazebo::components::JointVelocityCmd(
+                            {mimic_joint.multiplier * velocity_mimicked_joint});
+                }
+
+            }
+            if (mimic_interface == "effort"){
+
+                // TODO(ahcorde): Revisit this part ignitionrobotics/ign-physics#124
+                // Get the joint force
+                // const auto * jointForce =
+                //   _ecm.Component<ignition::gazebo::components::JointForce>(
+                //   this->dataPtr->sim_joints_[j]);
+
+                if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(
+                        this->dataPtr->joints_[mimic_joint.joint_index].sim_joint))
+                {
+                    this->dataPtr->ecm->CreateComponent(
+                            this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
+                            ignition::gazebo::components::JointForceCmd({0}));
+                } else {
+                    const auto jointEffortCmd =
+                            this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(
+                                    this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
+                    *jointEffortCmd = ignition::gazebo::components::JointForceCmd(
+                            {mimic_joint.multiplier * this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_effort});
+                }
+            }
+        }
   }
 
   return hardware_interface::return_type::OK;

--- a/ign_ros2_control_demos/CMakeLists.txt
+++ b/ign_ros2_control_demos/CMakeLists.txt
@@ -59,6 +59,12 @@ ament_target_dependencies(example_tricycle_drive
   geometry_msgs
 )
 
+add_executable(example_gripper examples/example_gripper.cpp)
+ament_target_dependencies(example_gripper
+  rclcpp
+  std_msgs
+)
+
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
@@ -74,6 +80,7 @@ install(
     example_effort
     example_diff_drive
     example_tricycle_drive
+    example_gripper
   DESTINATION
     lib/${PROJECT_NAME}
 )

--- a/ign_ros2_control_demos/config/gripper_controller.yaml
+++ b/ign_ros2_control_demos/config/gripper_controller.yaml
@@ -1,0 +1,15 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 100  # Hz
+
+    gripper_controller:
+      type: forward_command_controller/ForwardCommandController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+gripper_controller:
+  ros__parameters:
+    joints:
+      - right_finger_joint
+    interface_name: position

--- a/ign_ros2_control_demos/examples/example_gripper.cpp
+++ b/ign_ros2_control_demos/examples/example_gripper.cpp
@@ -1,0 +1,61 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Denis Štogl (Stogl Robotics Consulting)
+//
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/float64_multi_array.hpp"
+
+std::shared_ptr<rclcpp::Node> node;
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  node = std::make_shared<rclcpp::Node>("gripper_test_node");
+
+  auto publisher = node->create_publisher<std_msgs::msg::Float64MultiArray>(
+    "/gripper_controller/commands", 10);
+
+  RCLCPP_INFO(node->get_logger(), "node created");
+
+  std_msgs::msg::Float64MultiArray commands;
+
+  using namespace std::chrono_literals;
+
+  commands.data.push_back(0);
+  publisher->publish(commands);
+  std::this_thread::sleep_for(1s);
+
+  commands.data[0] = 0.38;
+  publisher->publish(commands);
+  std::this_thread::sleep_for(1s);
+
+  commands.data[0] = 0.19;
+  publisher->publish(commands);
+  std::this_thread::sleep_for(1s);
+
+  commands.data[0] = 0;
+  publisher->publish(commands);
+  std::this_thread::sleep_for(1s);
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
+++ b/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
@@ -15,98 +15,90 @@
 # Author: Denis Stogl (Stogl Robotics Consulting)
 #
 
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess, IncludeLaunchDescription, RegisterEventHandler
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
+
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
+
+import xacro
 
 
 def generate_launch_description():
+    # Launch arguments
+    use_sim_time = LaunchConfiguration('use_sim_time', default=True)
 
-    robot_description_content = Command(
-        [
-            PathJoinSubstitution([FindExecutable(name='xacro')]),
-            " ",
-            PathJoinSubstitution(
-                [FindPackageShare(
-                    'ign_ros2_control_demos'),
-                    'urdf',
-                    'test_gripper_mimic_joint.xacro.urdf']
-            ),
-        ]
-    )
-    robot_description = {"robot_description": robot_description_content}
+    ignition_ros2_control_demos_path = os.path.join(
+        get_package_share_directory('ign_ros2_control_demos'))
+
+    xacro_file = os.path.join(ignition_ros2_control_demos_path,
+                              'urdf',
+                              'test_gripper_mimic_joint.xacro.urdf')
+
+    doc = xacro.parse(open(xacro_file))
+    xacro.process_doc(doc)
+    params = {'robot_description': doc.toxml()}
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
         output='screen',
-        parameters=[robot_description]
+        parameters=[params]
     )
 
-    ignition = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            [FindPackageShare("ros_ign_gazebo"), "/launch", "/ign_gazebo.launch.py"]
-        ),
-        launch_arguments=[('ign_args', [' -r -v 3 empty.sdf'])],
+    ignition_spawn_entity = Node(
+        package='ros_ign_gazebo',
+        executable='create',
+        output='screen',
+        arguments=['-string', doc.toxml(),
+                   '-name', 'gripper',
+                   '-allow_renaming', 'true'],
     )
 
-    spawn_entity = Node(
-        package="ros_ign_gazebo",
-        executable="create",
-        output="screen",
-        arguments=[
-            "-param",
-            "robot_description",
-            "-name",
-            "gripper",
-            "-allow_renaming",
-            "true",
-            "-x",
-            "0.0",
-            "-y",
-            "0.0",
-            "-z",
-            "0.0",
-            "-R",
-            "0.0",
-            "-P",
-            "0.0",
-            "-Y",
-            "0.0",
-        ],
-        parameters=[robot_description]
-    )
-
-    load_joint_state_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'start',
+    load_joint_state_broadcaster = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
              'joint_state_broadcaster'],
         output='screen'
     )
 
     load_gripper_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'start',
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
              'gripper_controller'],
         output='screen'
     )
 
     return LaunchDescription([
+        # Launch gazebo environment
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [os.path.join(get_package_share_directory('ros_ign_gazebo'),
+                              'launch', 'ign_gazebo.launch.py')]),
+            launch_arguments=[('ign_args', [' -r -v 4 empty.sdf'])]),
         RegisterEventHandler(
-          event_handler=OnProcessExit(
-                target_action=spawn_entity,
-                on_exit=[load_joint_state_controller],
+            event_handler=OnProcessExit(
+                target_action=ignition_spawn_entity,
+                on_exit=[load_joint_state_broadcaster],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_controller,
+                target_action=load_joint_state_broadcaster,
                 on_exit=[load_gripper_controller],
             )
         ),
-        ignition,
         node_robot_state_publisher,
-        spawn_entity,
+        ignition_spawn_entity,
+        # Launch Arguments
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value=use_sim_time,
+            description='If true, use simulated clock'),
     ])

--- a/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
+++ b/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
@@ -1,0 +1,99 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Denis Stogl (Stogl Robotics Consulting)
+#
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, IncludeLaunchDescription, RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name='xacro')]),
+            " ",
+            PathJoinSubstitution(
+                [FindPackageShare(
+                    'ign_ros2_control_demos'),
+                    'urdf',
+                    'test_gripper_mimic_joint.xacro.urdf']
+            ),
+        ]
+    )
+    robot_description = {"robot_description": robot_description_content}
+
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[robot_description]
+    )
+
+    ignition = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [FindPackageShare("ros_ign_gazebo"), "/launch", "/ign_gazebo.launch.py"]
+        ),
+        launch_arguments=[('ign_args', [' -r -v 4 empty.sdf'])],
+    )
+
+    spawn_entity = Node(
+        package="ros_ign_gazebo",
+        executable="create",
+        output="screen",
+        arguments=[
+            "-string",
+            robot_description_content,
+            "-name",
+            "gripper",
+            "-allow_renaming",
+            "true",
+        ],
+    )
+
+    load_joint_state_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'start',
+             'joint_state_broadcaster'],
+        output='screen'
+    )
+
+    load_gripper_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'start',
+             'gripper_controller'],
+        output='screen'
+    )
+
+    return LaunchDescription([
+        RegisterEventHandler(
+          event_handler=OnProcessExit(
+                target_action=spawn_entity,
+                on_exit=[load_joint_state_controller],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_controller,
+                on_exit=[load_gripper_controller],
+            )
+        ),
+        ignition,
+        node_robot_state_publisher,
+        spawn_entity,
+    ])

--- a/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
+++ b/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
@@ -51,7 +51,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_ign_gazebo"), "/launch", "/ign_gazebo.launch.py"]
         ),
-        launch_arguments=[('ign_args', [' -r -v 4 empty.sdf'])],
+        launch_arguments=[('ign_args', [' -r -v 3 empty.sdf'])],
     )
 
     spawn_entity = Node(
@@ -59,13 +59,26 @@ def generate_launch_description():
         executable="create",
         output="screen",
         arguments=[
-            "-string",
-            robot_description_content,
+            "-param",
+            "robot_description",
             "-name",
             "gripper",
             "-allow_renaming",
             "true",
+            "-x",
+            "0.0",
+            "-y",
+            "0.0",
+            "-z",
+            "0.0",
+            "-R",
+            "0.0",
+            "-P",
+            "0.0",
+            "-Y",
+            "0.0",
         ],
+        parameters=[robot_description]
     )
 
     load_joint_state_controller = ExecuteProcess(

--- a/ign_ros2_control_demos/urdf/test_gripper_mimic_joint.xacro.urdf
+++ b/ign_ros2_control_demos/urdf/test_gripper_mimic_joint.xacro.urdf
@@ -1,0 +1,96 @@
+<?xml version="1.0" ?>
+<robot name="gripper">
+  <link name="world"/>
+  <link name="base">
+    <visual>
+      <geometry>
+        <box size="0.5 1 1"/>
+      </geometry>
+      <origin xyz="0 0 0.5"/>
+      <material name="violet">
+        <color rgba="0.4 0.18 0.57 1.0" />
+      </material>
+    </visual>
+    <inertial>
+      <mass value="50"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+    </inertial>
+  </link>
+  <link name="finger_right">
+    <visual>
+      <geometry>
+        <box size="0.4 0.1 1"/>
+      </geometry>
+      <origin xyz="0 0.05 0.5"/>
+      <material name="grey">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <inertial>
+      <mass value="5"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+    </inertial>
+  </link>
+  <link name="finger_left">
+    <visual>
+      <geometry>
+        <box size="0.4 0.1 1"/>
+      </geometry>
+      <origin xyz="0 0.05 0.5"/>
+      <material name="grey">
+        <color rgba="0.2 0.2 0.2 1"/>
+      </material>
+    </visual>
+    <inertial>
+      <mass value="5"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+    </inertial>
+  </link>
+  <joint name="world_to_base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="base"/>
+  </joint>
+  <joint name="right_finger_joint" type="prismatic">
+    <axis xyz="0 1 0"/>
+    <origin xyz="0.0 -0.48 1" rpy="0.0 0.0 0.0"/>
+    <parent link="base"/>
+    <child link="finger_right"/>
+    <limit effort="1000.0" lower="0" upper="0.38" velocity="10"/>
+  </joint>
+  <joint name="left_finger_joint" type="prismatic">
+    <mimic joint="right_finger_joint"/>
+    <axis xyz="0 1 0"/>
+    <origin xyz="0.0 0.48 1" rpy="0.0 0.0 3.1415926535"/>
+    <parent link="base"/>
+    <child link="finger_left"/>
+    <limit effort="1000.0" lower="0" upper="0.38" velocity="10"/>
+  </joint>
+  <ros2_control name="GripperIgnition" type="system">
+    <hardware>
+      <plugin>ign_ros2_control/IgnitionSystem</plugin>
+    </hardware>
+    <joint name="right_finger_joint">
+      <command_interface name="position"/>
+      <state_interface name="position">
+        <param name="initial_value">0.15</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="left_finger_joint">
+      <param name="mimic">right_finger_joint</param>
+      <param name="multiplier">1</param>
+      <command_interface name="position"/>
+      <state_interface name="position"/>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+  </ros2_control>
+
+  <gazebo>
+    <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+      <parameters>$(find ign_ros2_control_demos)/config/gripper_controller.yaml</parameters>
+    </plugin>
+  </gazebo>
+</robot>


### PR DESCRIPTION
This PR adds the same support for mimic joints as in ﻿ros-simulation/gazebo_ros2_control#107.

The code is just slightly adjusted to work with Ignition.

@ahcorde: I have a question regarding writing position commands to the simulator from the plugin. It is a bit different from for velocity and effort. Is this wrong? I have adjusted this in [8298604](https://github.com/ignitionrobotics/ign_ros2_control/pull/33/commits/82986048051db72ae2a2b50cb6ced69031fb2d0b).

Moreover, I have a compilation issue with this code, but there is no error output about it. Do you have any idea?
