### PR TITLE
Fix setting initial values if command interfaces are not defined.

### DIFF
--- a/ign_ros2_control/src/ign_system.cpp
+++ b/ign_ros2_control/src/ign_system.cpp
@@ -283,6 +283,19 @@ bool IgnitionSystem::initSim(
           this->dataPtr->joints_[j].joint_effort_cmd = initial_effort;
         }
       }
+      // independently of existence of command interface set initial value if defined
+      if (!std::isnan(initial_position)) {
+        const auto * jointPositions =
+          this->dataPtr->ecm->Component<ignition::gazebo::components::JointPosition>(
+          this->dataPtr->joints_[j].sim_joint);
+        this->dataPtr->joints_[j].joint_position = initial_position;
+      }
+      if (!std::isnan(initial_velocity)) {
+        const auto * jointVelocity =
+          this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocity>(
+          this->dataPtr->joints_[j].sim_joint);
+        this->dataPtr->joints_[j].joint_velocity = jointVelocity->Data()[0];
+      }
     }
   }
 

--- a/ign_ros2_control_demos/urdf/test_cart_effort.xacro.urdf
+++ b/ign_ros2_control_demos/urdf/test_cart_effort.xacro.urdf
@@ -52,7 +52,9 @@
         <param name="min">-15</param>
         <param name="max">15</param>
       </command_interface>
-      <state_interface name="position"/>
+      <state_interface name="position">
+        <param name="initial_value">1.0</param>
+      </state_interface>
       <state_interface name="velocity"/>
       <state_interface name="effort"/>
     </joint>


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

Related with https://github.com/ros-controls/gazebo_ros2_control/pull/110

The reason for the issue is that if the command interface does not exist, the initial value is never propagated to the simulator.
