### PR TITLE
added namespace to controller manager

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -412,7 +412,8 @@ void IgnitionROS2ControlPlugin::Configure(
     new controller_manager::ControllerManager(
       std::move(resource_manager_),
       this->dataPtr->executor_,
-      controllerManagerNodeName));
+      controllerManagerNodeName,
+      this->dataPtr->node_->get_namespace()));
   this->dataPtr->executor_->add_node(this->dataPtr->controller_manager_);
 
   if (!this->dataPtr->controller_manager_->has_parameter("update_rate")) {


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

Minor fix to allow CM to be run in the defined namespace, ref https://github.com/ros-controls/gazebo_ros2_control/pull/122

Related PR https://github.com/ros-controls/gazebo_ros2_control/pull/147