### PR TITLE
Fix Docker entrypoint and add launch CLI to dependencites

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV IGNITION_VERSION fortress
+ENV ROS_DISTRO rolling
 
 # Make sure everything is up to date before building from source
 RUN apt-get update \
@@ -30,10 +31,10 @@ RUN mkdir -p /home/ros2_ws/src \
     && cd /home/ros2_ws/src \
     && git clone https://github.com/ros-controls/gz_ros2_control/ \
     && rosdep init && rosdep update \
-    && rosdep install --from-paths ./ -i -y --rosdistro rolling
+    && rosdep install --from-paths ./ -i -y --rosdistro ${ROS_DISTRO}
 
 RUN cd /home/ros2_ws/ \
-  && . /opt/ros/rolling/setup.sh \
+  && . /opt/ros/"${ROS_DISTRO}"/setup.sh \
   && colcon build --merge-install
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile/entrypoint.sh
+++ b/Dockerfile/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-. /opt/ros/rolling/setup.sh
+. /opt/ros/"${ROS_DISTRO}"/setup.sh
 . /home/ros2_ws/install/setup.sh
 exec "$@"

--- a/Dockerfile/entrypoint.sh
+++ b/Dockerfile/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-. /opt/ros/"${ROS_DISTRO}"/setup.sh
+. /opt/ros/rolling/setup.sh
 . /home/ros2_ws/install/setup.sh
 exec "$@"

--- a/ign_ros2_control_demos/package.xml
+++ b/ign_ros2_control_demos/package.xml
@@ -33,6 +33,7 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros_ign_gazebo</exec_depend>


### PR DESCRIPTION
While trying to run the docker container, I found out that the ROS_DISTRO variable is not set. Since throughout the whole Dockerfile it is hard-coded to `rolling` I did the same for the `entrypoint.sh` file.

There was also missing `ros2launch` as a dependency inside `ign_ros2_control_demos`. Without that, I was unable to run the demos inside the Docker. The `ros2 launch` command was unavailable.