### PR TITLE
Mimic Joint Improvement

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -279,7 +279,8 @@ void IgnitionROS2ControlPlugin::Configure(
     controllerManagerNodeName = controllerManagerPrefixNodeName + "_" + controllerManagerNodeName;
   }
 
-  std::vector<std::string> arguments = {"--ros-args", "--params-file", paramFileName};
+  std::vector<std::string> arguments = {"--ros-args", "--params-file", paramFileName,
+                                        "--ros-args", "-p", "use_sim_time:=false"};
   auto sdfPtr = const_cast<sdf::Element *>(_sdf.get());
 
   if (sdfPtr->HasElement("ros")) {

--- a/ign_ros2_control/src/ign_system.cpp
+++ b/ign_ros2_control/src/ign_system.cpp
@@ -243,9 +243,11 @@ bool IgnitionSystem::initSim(
       }
 
       RCLCPP_INFO_STREAM(
-      this->nh_->get_logger(),
-      "Joint '" << this->dataPtr->joints_[mimic_joint.joint_index].name << "'is mimicking joint '" <<
-          this->dataPtr->joints_[mimic_joint.mimicked_joint_index].name << "' with multiplier: "<< mimic_joint.multiplier);
+        this->nh_->get_logger(),
+        "Joint '" << this->dataPtr->joints_[mimic_joint.joint_index].name <<
+          "'is mimicking joint '" <<
+          this->dataPtr->joints_[mimic_joint.mimicked_joint_index].name << "' with multiplier: " <<
+          mimic_joint.multiplier);
 
       this->dataPtr->mimic_joints_.push_back(mimic_joint);
       suffix = "_mimic";
@@ -509,9 +511,8 @@ IgnitionSystem::perform_command_mode_switch(
   const std::vector<std::string> & stop_interfaces)
 {
   for (unsigned int j = 0; j < this->dataPtr->joints_.size(); j++) {
-
     for (const std::string & interface_name : stop_interfaces) {
-        // Clear joint control method bits corresponding to stop interfaces
+      // Clear joint control method bits corresponding to stop interfaces
       if (interface_name == (this->dataPtr->joints_[j].name + "/" +
         hardware_interface::HW_IF_POSITION))
       {
@@ -552,48 +553,6 @@ IgnitionSystem::perform_command_mode_switch(
     }
   }
 
-  /*for (unsigned int i = 0; i < this->dataPtr->mimic_joints_.size(); ++i){
-      for (const std::string & interface_name : stop_interfaces) {
-          // Clear joint control method bits corresponding to stop interfaces
-          if (interface_name == (this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].mimicked_joint_index].name + "/" +
-                                 hardware_interface::HW_IF_POSITION))
-          {
-              this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].joint_index].joint_control_method &=
-                      static_cast<ControlMethod_>(VELOCITY & EFFORT);
-          }
-          if (interface_name == (this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].mimicked_joint_index].name + "/" +
-                                 hardware_interface::HW_IF_VELOCITY))
-          {
-              this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].joint_index].joint_control_method &=
-                      static_cast<ControlMethod_>(POSITION & EFFORT);
-          }
-          if (interface_name == (this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].mimicked_joint_index].name + "/" +
-                                 hardware_interface::HW_IF_EFFORT))
-          {
-              this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].joint_index].joint_control_method &=
-                      static_cast<ControlMethod_>(POSITION & VELOCITY);
-          }
-      }
-
-      for (const std::string & interface_name : start_interfaces) {
-          if (interface_name == (this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].mimicked_joint_index].name + "/" +
-                                 hardware_interface::HW_IF_POSITION))
-          {
-              this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].joint_index].joint_control_method |= POSITION;
-          }
-          if (interface_name == (this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].mimicked_joint_index].name + "/" +
-                                 hardware_interface::HW_IF_VELOCITY))
-          {
-              this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].joint_index].joint_control_method |= VELOCITY;
-          }
-          if (interface_name == (this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].mimicked_joint_index].name + "/" +
-                                 hardware_interface::HW_IF_EFFORT))
-          {
-              this->dataPtr->joints_[this->dataPtr->mimic_joints_[i].joint_index].joint_control_method |= EFFORT;
-          }
-      }
-  }*/
-
   return hardware_interface::return_type::OK;
 }
 
@@ -601,54 +560,67 @@ hardware_interface::return_type IgnitionSystem::write(
   const rclcpp::Time & /*time*/,
   const rclcpp::Duration & /*period*/)
 {
-    for (const auto & mimic_joint : this->dataPtr->mimic_joints_) {
+  for (const auto & mimic_joint : this->dataPtr->mimic_joints_) {
+    if (this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & POSITION) {
+      // Get error in position
+      double position_error =
+        this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_position *
+        mimic_joint.multiplier -
+        this->dataPtr->joints_[mimic_joint.joint_index].joint_position;
 
-        if (this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & POSITION)
-        {
-            // Get error in position
-            double position_error = this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_position * mimic_joint.multiplier -
-                    this->dataPtr->joints_[mimic_joint.joint_index].joint_position;
+      double velocity_sp = position_error * (*this->dataPtr->update_rate);
 
-            double velocity_sp = position_error * (*this->dataPtr->update_rate);
-
-            this->dataPtr->ecm->CreateComponent(
-                    this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
-                    ignition::gazebo::components::JointVelocityReset ({velocity_sp}));
-
-        }
-        if (this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & VELOCITY)
-        {
-            if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityReset>(
-                    this->dataPtr->joints_[mimic_joint.joint_index].sim_joint))
-            {
-                this->dataPtr->ecm->CreateComponent(
-                        this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
-                        ignition::gazebo::components::JointVelocityReset(
-                                {mimic_joint.multiplier * this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_velocity_cmd}));
-            } else {
-                const auto jointVelCmd =
-                        this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityReset>(
-                                this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
-                *jointVelCmd = ignition::gazebo::components::JointVelocityReset(
-                        {mimic_joint.multiplier * this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_velocity_cmd});
-            }
-        }
-        if (this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & EFFORT)
-        {
-
-        }
+      this->dataPtr->ecm->CreateComponent(
+        this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
+        ignition::gazebo::components::JointVelocityReset({velocity_sp}));
     }
+    if (this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & VELOCITY) {
+      if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityReset>(
+          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint))
+      {
+        this->dataPtr->ecm->CreateComponent(
+          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
+          ignition::gazebo::components::JointVelocityReset(
+            {mimic_joint.multiplier *
+              this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_velocity_cmd}));
+      } else {
+        const auto jointVelCmd =
+          this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityReset>(
+          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
+        *jointVelCmd = ignition::gazebo::components::JointVelocityReset(
+          {mimic_joint.multiplier *
+            this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_velocity_cmd});
+      }
+    }
+    if (this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_control_method & EFFORT) {
+      if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(
+          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint))
+      {
+        this->dataPtr->ecm->CreateComponent(
+          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint,
+          ignition::gazebo::components::JointForceCmd(
+            {mimic_joint.multiplier *
+              this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_effort_cmd}));
+      } else {
+        const auto jointEffortCmd =
+          this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(
+          this->dataPtr->joints_[mimic_joint.joint_index].sim_joint);
+        *jointEffortCmd = ignition::gazebo::components::JointForceCmd(
+          {mimic_joint.multiplier *
+            this->dataPtr->joints_[mimic_joint.mimicked_joint_index].joint_effort_cmd});
+      }
+    }
+  }
 
-    for (unsigned int i = 0; i < this->dataPtr->joints_.size(); ++i) {
-
-      if (this->dataPtr->joints_[i].joint_control_method & VELOCITY) {
+  for (unsigned int i = 0; i < this->dataPtr->joints_.size(); ++i) {
+    if (this->dataPtr->joints_[i].joint_control_method & VELOCITY) {
       if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityReset>(
           this->dataPtr->joints_[i].sim_joint))
       {
         this->dataPtr->ecm->CreateComponent(
           this->dataPtr->joints_[i].sim_joint,
           ignition::gazebo::components::JointVelocityReset(
-                  {this->dataPtr->joints_[i].joint_velocity_cmd}));
+            {this->dataPtr->joints_[i].joint_velocity_cmd}));
       } else {
         const auto jointVelCmd =
           this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityReset>(
@@ -658,36 +630,37 @@ hardware_interface::return_type IgnitionSystem::write(
       }
     }
 
-      if (this->dataPtr->joints_[i].joint_control_method & POSITION) {
+    if (this->dataPtr->joints_[i].joint_control_method & POSITION) {
+      // Get error in position
+      double error = this->dataPtr->joints_[i].joint_position_cmd -
+        this->dataPtr->joints_[i].joint_position;
 
-        // Get error in position
-        double error = this->dataPtr->joints_[i].joint_position_cmd - this->dataPtr->joints_[i].joint_position;
+      // Calculate target velocity
+      double maxVel = this->dataPtr->ecm->Component<ignition::gazebo::components::JointAxis>(
+        this->dataPtr->joints_[i].sim_joint)->Data().MaxVelocity();
+      double targetVel = std::clamp(error * (*this->dataPtr->update_rate), -1.0 * maxVel, maxVel);
 
-        // Calculate target velocity
-        double maxVel = this->dataPtr->ecm->Component<ignition::gazebo::components::JointAxis>(
-                this->dataPtr->joints_[i].sim_joint)->Data().MaxVelocity();
-        double targetVel = std::clamp(error * (*this->dataPtr->update_rate), -1.0 * maxVel, maxVel);
+      auto vel =
+        this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityReset>(
+        this->dataPtr->joints_[i].sim_joint);
 
-        auto vel =
-          this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityReset>(
-          this->dataPtr->joints_[i].sim_joint);
-
-        if (vel == nullptr) {
-          this->dataPtr->ecm->CreateComponent(
-            this->dataPtr->joints_[i].sim_joint,
-            ignition::gazebo::components::JointVelocityReset({targetVel}));
-        } else if (!vel->Data().empty()) {
-          vel->Data()[0] = targetVel;
-        }
+      if (vel == nullptr) {
+        this->dataPtr->ecm->CreateComponent(
+          this->dataPtr->joints_[i].sim_joint,
+          ignition::gazebo::components::JointVelocityReset({targetVel}));
+      } else if (!vel->Data().empty()) {
+        vel->Data()[0] = targetVel;
       }
+    }
 
-      if (this->dataPtr->joints_[i].joint_control_method & EFFORT) {
+    if (this->dataPtr->joints_[i].joint_control_method & EFFORT) {
       if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(
           this->dataPtr->joints_[i].sim_joint))
       {
         this->dataPtr->ecm->CreateComponent(
           this->dataPtr->joints_[i].sim_joint,
-          ignition::gazebo::components::JointForceCmd({this->dataPtr->joints_[i].joint_effort_cmd}));
+          ignition::gazebo::components::JointForceCmd(
+            {this->dataPtr->joints_[i].joint_effort_cmd}));
       } else {
         const auto jointEffortCmd =
           this->dataPtr->ecm->Component<ignition::gazebo::components::JointForceCmd>(

--- a/ign_ros2_control_demos/config/gripper_controller.yaml
+++ b/ign_ros2_control_demos/config/gripper_controller.yaml
@@ -5,6 +5,9 @@ controller_manager:
     gripper_controller:
       type: forward_command_controller/ForwardCommandController
 
+    gripper_action_controller:
+      type: position_controllers/GripperActionController
+
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
@@ -13,3 +16,8 @@ gripper_controller:
     joints:
       - right_finger_joint
     interface_name: position
+
+gripper_action_controller:
+  ros__parameters:
+    default: true
+    joint: right_finger_joint

--- a/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
+++ b/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
@@ -75,13 +75,20 @@ def generate_launch_description():
         output='screen'
     )
 
+    # load action controller but don't start it
+    load_gripper_action_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'configured',
+             'gripper_action_controller'],
+        output='screen'
+    )
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
                 [os.path.join(get_package_share_directory('ros_ign_gazebo'),
                               'launch', 'ign_gazebo.launch.py')]),
-            launch_arguments=[('ign_args', [' -r -v 4 empty.sdf'])]),
+            launch_arguments=[('ign_args', [' -r -v 3 empty.sdf'])]),
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=ignition_spawn_entity,
@@ -92,6 +99,12 @@ def generate_launch_description():
             event_handler=OnProcessExit(
                 target_action=load_joint_state_broadcaster,
                 on_exit=[load_gripper_controller],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_gripper_controller,
+                on_exit=[load_gripper_action_controller],
             )
         ),
         node_robot_state_publisher,


### PR DESCRIPTION
After ros-controls/gz_ros2_control#33 has been merged I stumbled upon small errors and spaces for improvement.
PR info:
- moving from `JointVelocityCmd` to `JointVelocityReset` because there was an error in handling joint limits and recovery from hitting them (more information can be found [here](https://github.com/gazebosim/gz-sim/issues/1684) )
- mimic joint control method is now handled in `perform_command_mode_switch` which is called upon any controller switch.