### PR TITLE
Context and Namespace Handling for Multi-Robot Sim

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -285,12 +285,6 @@ void IgnitionROS2ControlPlugin::Configure(
   // Get controller manager node name
   std::string controllerManagerNodeName{"controller_manager"};
 
-  std::string controllerManagerPrefixNodeName =
-    _sdf->Get<std::string>("controller_manager_prefix_node_name");
-  if (!controllerManagerPrefixNodeName.empty()) {
-    controllerManagerNodeName = controllerManagerPrefixNodeName + "_" + controllerManagerNodeName;
-  }
-
   std::string ns = "/";
   if (sdfPtr->HasElement("ros")) {
     sdf::ElementPtr sdfRos = sdfPtr->GetElement("ros");
@@ -332,9 +326,6 @@ void IgnitionROS2ControlPlugin::Configure(
   }
 
   std::string node_name = "ignition_ros_control";
-  if (!controllerManagerPrefixNodeName.empty()) {
-    node_name = controllerManagerPrefixNodeName + "_" + node_name;
-  }
 
   this->dataPtr->node_ = rclcpp::Node::make_shared(node_name, ns);
   this->dataPtr->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -296,11 +296,20 @@ void IgnitionROS2ControlPlugin::Configure(
     argv.push_back(reinterpret_cast<const char *>(arg.data()));
   }
 
+  // Get controller manager node name
+  std::string controllerManagerNodeName{"controller_manager"};
+  std::string controllerManagerPrefixNodeName =
+    _sdf->Get<std::string>("controller_manager_prefix_node_name");
+  if (!controllerManagerPrefixNodeName.empty()) {
+    controllerManagerNodeName = controllerManagerPrefixNodeName + "_" + controllerManagerNodeName;
+  }
+
   auto sdfPtr = const_cast<sdf::Element *>(_sdf.get());
+
   if (sdfPtr->HasElement("ros")) {
     sdf::ElementPtr sdfRos = sdfPtr->GetElement("ros");
 
-    // Set namespace if tag is present 
+    // Set namespace if tag is present
     if (sdfRos->HasElement("namespace")) {
       std::string ns = sdfRos->GetElement("namespace")->Get<std::string>();
       // prevent exception: namespace must be absolute, it must lead with a '/'
@@ -421,7 +430,7 @@ void IgnitionROS2ControlPlugin::Configure(
     new controller_manager::ControllerManager(
       std::move(resource_manager_),
       this->dataPtr->executor_,
-      "controller_manager",
+      controllerManagerNodeName,
       this->dataPtr->robot_namespace_));
   this->dataPtr->executor_->add_node(this->dataPtr->controller_manager_);
 

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -325,7 +325,7 @@ void IgnitionROS2ControlPlugin::Configure(
     rclcpp::init(static_cast<int>(argv.size()), argv.data());
   }
 
-  std::string node_name = "ignition_ros_control";
+  std::string node_name = "gz_ros2_control";
 
   this->dataPtr->node_ = rclcpp::Node::make_shared(node_name, ns);
   this->dataPtr->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -275,6 +275,7 @@ void IgnitionROS2ControlPlugin::Configure(
 
   std::vector<std::string> arguments = {"--ros-args", "--params-file", paramFileName};
   auto sdfPtr = const_cast<sdf::Element *>(_sdf.get());
+  
   sdf::ElementPtr argument_sdf = sdfPtr->GetElement("parameters");
   while (argument_sdf) {
     std::string argument = argument_sdf->Get<std::string>();
@@ -290,6 +291,7 @@ void IgnitionROS2ControlPlugin::Configure(
     _sdf->Get<std::string>("controller_manager_prefix_node_name");
   if (!controllerManagerPrefixNodeName.empty()) {
     controllerManagerNodeName = controllerManagerPrefixNodeName + "_" + controllerManagerNodeName;
+  }
 
   if (sdfPtr->HasElement("ros")) {
     sdf::ElementPtr sdfRos = sdfPtr->GetElement("ros");

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -274,8 +274,9 @@ void IgnitionROS2ControlPlugin::Configure(
   }
 
   std::vector<std::string> arguments = {"--ros-args", "--params-file", paramFileName};
+
   auto sdfPtr = const_cast<sdf::Element *>(_sdf.get());
-  
+
   sdf::ElementPtr argument_sdf = sdfPtr->GetElement("parameters");
   while (argument_sdf) {
     std::string argument = argument_sdf->Get<std::string>();

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -95,6 +95,9 @@ public:
   // TODO(ahcorde): Add param in plugin tag
   std::string robot_description_node_ = "robot_state_publisher";
 
+  /// \brief String with the namesapce of the robot to cascade to all sub-nodes
+  std::string robot_namespace_ = ""
+
   /// \brief Last time the update method was called
   rclcpp::Time last_update_sim_time_ros_ =
     rclcpp::Time((int64_t)0, RCL_ROS_TIME);
@@ -291,30 +294,42 @@ void IgnitionROS2ControlPlugin::Configure(
     controllerManagerNodeName = controllerManagerPrefixNodeName + "_" + controllerManagerNodeName;
   }
 
+  // TODO Figure out if this is used, if yes it means we will require the use of the context, otherwise remove altogether
+  std::vector<std::string> arguments = {"--ros-args", "--params-file", paramFileName};
+  auto sdfPtr = const_cast<sdf::Element *>(_sdf.get());
+
   if (sdfPtr->HasElement("ros")) {
     sdf::ElementPtr sdfRos = sdfPtr->GetElement("ros");
 
-    // Set namespace if tag is present
+    // Set namespace if tag is present 
     if (sdfRos->HasElement("namespace")) {
       std::string ns = sdfRos->GetElement("namespace")->Get<std::string>();
+      std::cout << "#################### DEBUG namespace:" << ns << std::endl;
       // prevent exception: namespace must be absolute, it must lead with a '/'
       if (ns.empty() || ns[0] != '/') {
         ns = '/' + ns;
       }
-      std::string ns_arg = std::string("__ns:=") + ns;
-      arguments.push_back(RCL_REMAP_FLAG);
-      arguments.push_back(ns_arg);
+      if(ns.length()>1) {
+        this->dataPtr->namespace_ = ns;
+        this->dataPtr->robot_description_node_ = ns + "/robot_state_publisher";
+      }
+
+      // TODO Figure out if this is used, if yes it means we will require the use of the context, otherwise remove altogether
+      //std::string ns_arg = std::string("__ns:=") + ns;
+      //arguments.push_back(RCL_REMAP_FLAG);
+      //arguments.push_back(ns_arg);
     }
 
     // Get list of remapping rules from SDF
     if (sdfRos->HasElement("remapping")) {
       sdf::ElementPtr argument_sdf = sdfRos->GetElement("remapping");
 
-      arguments.push_back(RCL_ROS_ARGS_FLAG);
+    // TODO Figure out if this is used, if yes it means we will require the use of the context, otherwise remove altogether
+    //  arguments.push_back(RCL_ROS_ARGS_FLAG);
       while (argument_sdf) {
         std::string argument = argument_sdf->Get<std::string>();
-        arguments.push_back(RCL_REMAP_FLAG);
-        arguments.push_back(argument);
+    //    arguments.push_back(RCL_REMAP_FLAG);
+    //    arguments.push_back(argument);
         argument_sdf = argument_sdf->GetNextElement("remapping");
       }
     }

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -265,7 +265,6 @@ void IgnitionROS2ControlPlugin::Configure(
 
   // Get params from SDF
   std::string paramFileName = _sdf->Get<std::string>("parameters");
-  std::vector<std::string> arguments = {"--ros-args", "--params-file", paramFileName};
 
   if (paramFileName.empty()) {
     RCLCPP_ERROR(
@@ -274,6 +273,7 @@ void IgnitionROS2ControlPlugin::Configure(
     return;
   }
 
+  std::vector<std::string> arguments = {"--ros-args", "--params-file", paramFileName};
   auto sdfPtr = const_cast<sdf::Element *>(_sdf.get());
   sdf::ElementPtr argument_sdf = sdfPtr->GetElement("parameters");
   while (argument_sdf) {
@@ -290,21 +290,6 @@ void IgnitionROS2ControlPlugin::Configure(
     _sdf->Get<std::string>("controller_manager_prefix_node_name");
   if (!controllerManagerPrefixNodeName.empty()) {
     controllerManagerNodeName = controllerManagerPrefixNodeName + "_" + controllerManagerNodeName;
-  
-  std::vector<const char *> argv;
-  for (const auto & arg : arguments) {
-    argv.push_back(reinterpret_cast<const char *>(arg.data()));
-  }
-
-  // Get controller manager node name
-  std::string controllerManagerNodeName{"controller_manager"};
-  std::string controllerManagerPrefixNodeName =
-    _sdf->Get<std::string>("controller_manager_prefix_node_name");
-  if (!controllerManagerPrefixNodeName.empty()) {
-    controllerManagerNodeName = controllerManagerPrefixNodeName + "_" + controllerManagerNodeName;
-  }
-
-  auto sdfPtr = const_cast<sdf::Element *>(_sdf.get());
 
   if (sdfPtr->HasElement("ros")) {
     sdf::ElementPtr sdfRos = sdfPtr->GetElement("ros");
@@ -325,6 +310,7 @@ void IgnitionROS2ControlPlugin::Configure(
     // Get list of remapping rules from SDF
     if (sdfRos->HasElement("remapping")) {
       sdf::ElementPtr argument_sdf = sdfRos->GetElement("remapping");
+
       arguments.push_back(RCL_ROS_ARGS_FLAG);
       while (argument_sdf) {
         std::string argument = argument_sdf->Get<std::string>();
@@ -333,6 +319,11 @@ void IgnitionROS2ControlPlugin::Configure(
         argument_sdf = argument_sdf->GetNextElement("remapping");
       }
     }
+  }
+
+  std::vector<const char *> argv;
+  for (const auto & arg : arguments) {
+    argv.push_back(reinterpret_cast<const char *>(arg.data()));
   }
 
   // Create a default context, if not already

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -341,7 +341,9 @@ void IgnitionROS2ControlPlugin::Configure(
   }
 
   // Instanciate and start node with namespace
-  this->dataPtr->node_ = rclcpp::Node::make_shared("ignition_ros_control", this->dataPtr->robot_namespace_);
+  this->dataPtr->node_ = rclcpp::Node::make_shared(
+    "ignition_ros_control",
+    this->dataPtr->robot_namespace_);
   this->dataPtr->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   this->dataPtr->executor_->add_node(this->dataPtr->node_);
   this->dataPtr->stop_ = false;

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -254,7 +254,6 @@ void IgnitionROS2ControlPlugin::Configure(
   ignition::gazebo::EntityComponentManager & _ecm,
   ignition::gazebo::EventManager &)
 {
-
   // Make sure the controller is attached to a valid model
   const auto model = ignition::gazebo::Model(_entity);
   if (!model.Valid(_ecm)) {
@@ -310,14 +309,9 @@ void IgnitionROS2ControlPlugin::Configure(
       if (ns.empty() || ns[0] != '/') {
         ns = '/' + ns;
       }
-      if(ns.length()>1) {
+      if (ns.length() > 1) {
         this->dataPtr->robot_namespace_ = ns;
         this->dataPtr->robot_description_node_ = ns + "/robot_state_publisher";
-        
-        // TODO check if node names need to be prefixed
-        //ns.erase(0, 1); //removing '/' for node names 
-        //this->dataPtr->robot_description_ = ns + "_robot_description";
-        //this->dataPtr->controller_manager_node_ = ns + "_controller_manager";
       }
     }
 
@@ -334,10 +328,7 @@ void IgnitionROS2ControlPlugin::Configure(
     }
   }
 
-
   // Create a default context, if not already
-  // This only triggers for the first robot launch, 
-  // following robots will not see their params passed to the context 
   if (!rclcpp::ok()) {
     rclcpp::init(static_cast<int>(argv.size()), argv.data());
   }
@@ -370,7 +361,6 @@ void IgnitionROS2ControlPlugin::Configure(
       "[Ignition ROS 2 Control] There are no available Joints.");
     return;
   }
-
 
   // Read urdf from ros parameter server then
   // setup actuators and mechanism control node.


### PR DESCRIPTION
## Description

The goal of this PR is to enable namespaces and prevent segmentation faults when spawning multiple time the same robot

Type of change: fix. This change aims at fixing the following open issue: https://github.com/ros-controls/gz_ros2_control/issues/49 

An existing PR seems to be targeting the namespace issue: https://github.com/ros-controls/gz_ros2_control/pull/77. But it does not solve the context and controller manager node name issues

## How has this been tested?

We have tested this code on create3 and turtlebot4 robots. You can find our project here: https://github.com/sp-sophia-labs/turtlebot4_multi_sim.  Reviewers may clone the project and replicate exactly what we use for testing. Here are the launch commands (you can find the details in the project's README)

Launch the world and the first create3 instance:
`ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py namespace:=robot_0 robot_name:=robot_zero`

Alternatively, you can launch turtlebot4 instead:
`ros2 launch turtlebot4_ignition_bringup ignition.launch.py namespace:=robot_0 robot_name:=robot_zero`

In a separate terminal, spawn another create3/turtlebot4 instance with different name, namespace and pose:
`ros2 launch irobot_create_ignition_bringup create3_spawn.launch.py namespace:=robot_1 robot_name:=robot_one y:=1`
`ros2 launch irobot_create_ignition_bringup turtlebot4_spawn.launch.py namespace:=robot_1 robot_name:=robot_one y:=1`
You can change the x, y, z param to spawn the robot where needed

## Checklist

- [x] Lint code with appropriate parser
- [x] Evaluate a more elegant way to get robot namespace (cf. the other pull request)
- [x] Rebase code on galactic branch 