### PR TITLE
Force setting use_sim_time parameter when using plugin.

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -428,6 +428,9 @@ void IgnitionROS2ControlPlugin::Configure(
     std::chrono::duration_cast<std::chrono::nanoseconds>(
       std::chrono::duration<double>(1.0 / static_cast<double>(this->dataPtr->update_rate))));
 
+  // Force setting of use_sime_time parameter
+  this->dataPtr->controller_manager_->set_parameter(rclcpp::Parameter("use_sim_time", rclcpp::ParameterValue(true)));
+
   this->dataPtr->entity_ = _entity;
 }
 

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -429,7 +429,8 @@ void IgnitionROS2ControlPlugin::Configure(
       std::chrono::duration<double>(1.0 / static_cast<double>(this->dataPtr->update_rate))));
 
   // Force setting of use_sime_time parameter
-  this->dataPtr->controller_manager_->set_parameter(rclcpp::Parameter("use_sim_time", rclcpp::ParameterValue(true)));
+  this->dataPtr->controller_manager_->set_parameter(
+    rclcpp::Parameter("use_sim_time", rclcpp::ParameterValue(true)));
 
   this->dataPtr->entity_ = _entity;
 }


### PR DESCRIPTION
Proposal to force setting parameter for controller manager and controller so we don't have to adjust controllers.yaml file.
This will reduce user errors and make controllers.yaml file more compatible for other use-cases, e.g. when using Mock and real hardware.
