### PR TITLE
Force setting use_sim_time parameter when using plugin. (#100)

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -431,6 +431,10 @@ void IgnitionROS2ControlPlugin::Configure(
     std::chrono::duration_cast<std::chrono::nanoseconds>(
       std::chrono::duration<double>(1.0 / static_cast<double>(this->dataPtr->update_rate))));
 
+  // Force setting of use_sime_time parameter
+  this->dataPtr->controller_manager_->set_parameter(
+    rclcpp::Parameter("use_sim_time", rclcpp::ParameterValue(true)));
+
   this->dataPtr->entity_ = _entity;
 }
 


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>
