### PR TITLE
Disable ROS signal handlers

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -334,7 +334,9 @@ void GazeboSimROS2ControlPlugin::Configure(
   }
   // Create a default context, if not already
   if (!rclcpp::ok()) {
-    rclcpp::init(static_cast<int>(argv.size()), argv.data());
+    rclcpp::init(
+      static_cast<int>(argv.size()), argv.data(), rclcpp::InitOptions(),
+      rclcpp::SignalHandlerOptions::None);
   }
 
   std::string node_name = "gz_ros_control";


### PR DESCRIPTION
Hi all,
I believe it would be best to disable the ROS signal handlers from the plugin ROS node. Right now the signal handlers cannot be disabled, and this can become problematic. For example in my current workflow I am running gazebo (in a similar way to what TestFixture does [https://gazebosim.org/api/sim/7/classgz_1_1sim_1_1TestFixture.html](https://gazebosim.org/api/sim/7/classgz_1_1sim_1_1TestFixture.html)) within a python process that has its own signal handlers. 
Also, i am not sure what purpose having them enabled could serve.
Also with gazebo classic ROS signal handlers were disabled, [https://github.com/ros-simulation/gazebo_ros_pkgs/blob/398cde933cba5d72921055d57d4faa47c4445654/gazebo_ros/src/gazebo_ros_api_plugin.cpp#L126](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/398cde933cba5d72921055d57d4faa47c4445654/gazebo_ros/src/gazebo_ros_api_plugin.cpp#L126)
It's a very small change, what do you think?

Thanks for all the work!