### PR TITLE
Cleanup controller config

### DIFF
--- a/gz_ros2_control_demos/config/cartpole_controller_effort.yaml
+++ b/gz_ros2_control_demos/config/cartpole_controller_effort.yaml
@@ -2,19 +2,13 @@ controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
 
-    effort_controllers:
+    effort_controller:
       type: effort_controllers/JointGroupEffortController
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-effort_controllers:
+effort_controller:
   ros__parameters:
     joints:
       - slider_to_cart
-    command_interfaces:
-      - effort
-    state_interfaces:
-      - position
-      - velocity
-      - effort

--- a/gz_ros2_control_demos/config/cartpole_controller_velocity.yaml
+++ b/gz_ros2_control_demos/config/cartpole_controller_velocity.yaml
@@ -15,11 +15,6 @@ velocity_controller:
   ros__parameters:
     joints:
       - slider_to_cart
-    command_interfaces:
-      - velocity
-    state_interfaces:
-      - position
-      - velocity
 
 imu_sensor_broadcaster:
   ros__parameters:

--- a/gz_ros2_control_demos/examples/example_effort.cpp
+++ b/gz_ros2_control_demos/examples/example_effort.cpp
@@ -26,7 +26,7 @@ int main(int argc, char * argv[])
     std::make_shared<rclcpp::Node>("effort_test_node");
 
   auto publisher = node->create_publisher<std_msgs::msg::Float64MultiArray>(
-    "/effort_controllers/commands", 10);
+    "/effort_controller/commands", 10);
 
   RCLCPP_INFO(node->get_logger(), "node created");
 

--- a/gz_ros2_control_demos/launch/cart_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/cart_example_effort.launch.py
@@ -67,7 +67,7 @@ def generate_launch_description():
     )
 
     load_joint_effort_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active', 'effort_controllers'],
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active', 'effort_controller'],
         output='screen'
     )
 


### PR DESCRIPTION
Related with this PR in gazebo_ros2_control https://github.com/ros-controls/gazebo_ros2_control/pull/232

The controller config of the velocity and effort controllers (specializations of the forward_command_controller) had some non-existing parameters in the yaml.