### PR TITLE
Add controller name parameter

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -286,6 +286,10 @@ void IgnitionROS2ControlPlugin::Configure(
   // Get controller manager node name
   std::string controllerManagerNodeName{"controller_manager"};
 
+  if (sdfPtr->HasElement("controller_manager_name")){
+    controllerManagerNodeName = sdfPtr->GetElement("controller_manager_name")->Get<std::string>();
+  }
+
   std::string ns = "/";
   if (sdfPtr->HasElement("ros")) {
     sdf::ElementPtr sdfRos = sdfPtr->GetElement("ros");


### PR DESCRIPTION
This PR resolves this issue https://github.com/ros-controls/gz_ros2_control/issues/187

It is great feature to use the same config file for real and simulated robot, urdf:
```xml
<gazebo>
  <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">

    <xacro:if value="${mecanum}">
      <parameters>$(find rosbot_controller)/config/mecanum_drive_controller.yaml</parameters>
    </xacro:if>
    <xacro:unless value="${mecanum}">
      <parameters>$(find rosbot_controller)/config/diff_drive_controller.yaml</parameters>
    </xacro:unless>

    <controller_manager_name>simulation_controller_manager</controller_manager_name>

    <ros>
      <namespace>${gz_control_namespace}</namespace>
      <remapping>rosbot_base_controller/cmd_vel_unstamped:=cmd_vel</remapping>
      <remapping>/tf:=tf</remapping>
    </ros>
  </plugin>
</gazebo>
```

config:
```yaml
/**/simulation_controller_manager:
  ros__parameters:
    use_sim_time: True
    update_rate: 20 # Hz

    joint_state_broadcaster:
      type: joint_state_broadcaster/JointStateBroadcaster
    rosbot_base_controller:
      type: diff_drive_controller/DiffDriveController
    imu_broadcaster:
      type: imu_sensor_broadcaster/IMUSensorBroadcaster

/**/controller_manager:
  ros__parameters:
    use_sim_time: False
    update_rate: 20 # Hz

    joint_state_broadcaster:
      type: joint_state_broadcaster/JointStateBroadcaster
    rosbot_base_controller:
      type: diff_drive_controller/DiffDriveController
    imu_broadcaster:
      type: imu_sensor_broadcaster/IMUSensorBroadcaster
```