### PR TITLE
Fix typo in checking the output

### DIFF
--- a/gz_ros2_control_tests/tests/position_test.py
+++ b/gz_ros2_control_tests/tests/position_test.py
@@ -120,7 +120,7 @@ def generate_test_description():
 class TestFixture(unittest.TestCase):
 
     def test_arm(self, launch_service, proc_info, proc_output):
-        proc_output.assertWaitFor('Sucessfully loaded controller joint_trajectory_controller '
+        proc_output.assertWaitFor('Successfully loaded controller joint_trajectory_controller '
                                   'into state active',
                                   timeout=100, stream='stdout')
 


### PR DESCRIPTION
This should fix https://github.com/ros-controls/ros2_control_ci/issues/26 and https://github.com/ros-controls/ros2_control_ci/issues/25.