### PR TITLE
Fix #247 - explicitly declare `position_proportional_gain` parameter

### DIFF
--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -234,15 +234,14 @@ bool GazeboSimSystem::initSim(
   this->dataPtr->joints_.resize(this->dataPtr->n_dof_);
 
   constexpr double default_gain = 0.1;
-  if (!this->nh_->get_parameter_or(
-      "position_proportional_gain",
-      this->dataPtr->position_proportional_gain_, default_gain))
-  {
-    RCLCPP_WARN_STREAM(
-      this->nh_->get_logger(),
-      "The position_proportional_gain parameter was not defined, defaulting to: " <<
-        default_gain);
-  }
+
+  this->dataPtr->position_proportional_gain_ = this->nh_->declare_parameter<double>(
+    "position_proportional_gain", default_gain);
+
+  RCLCPP_INFO_STREAM(
+    this->nh_->get_logger(),
+    "The position_proportional_gain has been set to: " <<
+      this->dataPtr->position_proportional_gain_);
 
   if (this->dataPtr->n_dof_ == 0) {
     RCLCPP_ERROR_STREAM(this->nh_->get_logger(), "There is no joint available");


### PR DESCRIPTION
With this patch, you can change position gain with this config file lines:

```yaml
gz_ros_control:
  ros__parameters:
    position_proportional_gain: 0.5
```