### PR TITLE
New branch and fix API breaking to allow Humble to work with Gazebo Garden

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -414,7 +414,7 @@ void GazeboSimROS2ControlPlugin::Configure(
   }
 
   for (unsigned int i = 0; i < control_hardware_info.size(); ++i) {
-    std::string robot_hw_sim_type_str_ = control_hardware_info[i].hardware_plugin_name;
+    std::string robot_hw_sim_type_str_ = control_hardware_info[i].hardware_class_type;
     RCLCPP_DEBUG(
       this->dataPtr->node_->get_logger(), "Load hardware interface %s ...",
       robot_hw_sim_type_str_.c_str());


### PR DESCRIPTION
Hi guys,
I created this PR to allow Humble to work with Gazebo Garden. 
I started to work with iron branch because it contains the porting from ignition to gazebo API. I discovered that the ros2_control repository has changed the API from Humble to Iron. Therefore, I updated the code with old version of ros2_control's API. 

It seems to work without problem with Humble and Garden. My idea is to keep a two different branches, so a person can choose if need to work with Gazebo Garden or Ignition Fortress.

Tell me what do you think about this idea  


