### PR TITLE
Added parameters robot_param and robot_param_node

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -92,11 +92,9 @@ public:
   controller_manager_{nullptr};
 
   /// \brief String with the robot description param_name
-  // TODO(ahcorde): Add param in plugin tag
   std::string robot_description_ = "robot_description";
 
   /// \brief String with the name of the node that contains the robot_description
-  // TODO(ahcorde): Add param in plugin tag
   std::string robot_description_node_ = "robot_state_publisher";
 
   /// \brief Last time the update method was called
@@ -274,6 +272,23 @@ void IgnitionROS2ControlPlugin::Configure(
       "Ignition ros2 control found an empty parameters file. Failed to initialize.");
     return;
   }
+
+  // Get params from SDF
+  std::string robot_param_node = _sdf->Get<std::string>("robot_param_node");
+  if (!robot_param_node.empty()) {
+    this->dataPtr->robot_description_node_ = robot_param_node;
+  }
+  RCLCPP_INFO(
+    logger,
+    "robot_param_node is %s", this->dataPtr->robot_description_node_.c_str());
+
+  std::string robot_description = _sdf->Get<std::string>("robot_param");
+  if (!robot_description.empty()) {
+    this->dataPtr->robot_description_ = robot_description;
+  }
+  RCLCPP_INFO(
+    logger,
+    "robot_param_node is %s", this->dataPtr->robot_description_.c_str());
 
   std::vector<std::string> arguments = {"--ros-args"};
 


### PR DESCRIPTION
Related with this PR https://github.com/ros-controls/gz_ros2_control/issues/274

Allow to use these two paramaters

```xml
<plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
  <parameters>$(find my_description)/config/default_controller.yaml</parameters>
  <robot_param>robot_description</robot_param>
  <robot_param_node>my_robot_state_publisher</robot_param_node>
</plugin>
```