### PR TITLE
Add cart-pole demo

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,12 +10,6 @@ This is a ROS 2 package for integrating the *ros2_control* controller architectu
 
 This package provides a Gazebo-Sim system plugin which instantiates a *ros2_control* controller manager and connects it to a Gazebo model.
 
-.. image:: img/gz_ros2_control.gif
-  :alt: Cart
-
-.. image:: img/diff_drive.gif
-  :alt: DiffBot
-
 Usage
 ======
 
@@ -212,7 +206,15 @@ The following is a basic configuration of the controllers:
 gz_ros2_control_demos
 ==========================================
 
-There are some examples in the *gz_ros2_control_demos* package. These examples allow to launch a cart in a 30 meter rail.
+There are some examples in the *gz_ros2_control_demos* package.
+
+Cart on rail
+-----------------------------------------------------------
+
+These examples allow to launch a cart in a 30 meter rail.
+
+.. image:: img/gz_ros2_control.gif
+  :alt: Cart
 
 You can run some of the example configurations by running the following commands:
 
@@ -221,8 +223,6 @@ You can run some of the example configurations by running the following commands
   ros2 launch gz_ros2_control_demos cart_example_position.launch.py
   ros2 launch gz_ros2_control_demos cart_example_velocity.launch.py
   ros2 launch gz_ros2_control_demos cart_example_effort.launch.py
-  ros2 launch gz_ros2_control_demos diff_drive_example.launch.py
-  ros2 launch gz_ros2_control_demos tricycle_drive_example.launch.py
 
 When the Gazebo world is launched, you can run some of the following commands to move the cart.
 
@@ -231,10 +231,31 @@ When the Gazebo world is launched, you can run some of the following commands to
   ros2 run gz_ros2_control_demos example_position
   ros2 run gz_ros2_control_demos example_velocity
   ros2 run gz_ros2_control_demos example_effort
+
+Mobile robots
+-----------------------------------------------------------
+
+.. image:: img/diff_drive.gif
+  :alt: DiffBot
+
+You can run some of the mobile robots running the following commands:
+
+.. code-block:: shell
+
+  ros2 launch gz_ros2_control_demos diff_drive_example.launch.py
+  ros2 launch gz_ros2_control_demos tricycle_drive_example.launch.py
+
+When the Gazebo world is launched you can run some of the following commands to move the robots.
+
+.. code-block:: shell
+
   ros2 run gz_ros2_control_demos example_diff_drive
   ros2 run gz_ros2_control_demos example_tricycle_drive
 
-The following example shows parallel gripper with mimic joint:
+Gripper
+-----------------------------------------------------------
+
+The following example shows a parallel gripper with a mimic joint:
 
 .. code-block:: shell
 
@@ -254,7 +275,24 @@ instead.
 
 Send example commands:
 
-
 .. code-block:: shell
 
   ros2 run gz_ros2_control_demos example_gripper
+
+
+Pendulum with passive joints (cart-pole)
+-----------------------------------------------------------
+
+The following example shows a cart with a pendulum arm:
+
+.. code-block:: shell
+
+  ros2 launch gz_ros2_control_demos pendulum_example_effort.launch.py
+  ros2 run gz_ros2_control_demos example_effort
+
+This uses the effort command interface for the cart's degree of freedom on the rail. To demonstrate that the physics of the passive joint of the pendulum is solved correctly even with the position command interface, run
+
+.. code-block:: shell
+
+  ros2 launch gz_ros2_control_demos pendulum_example_position.launch.py
+  ros2 run gz_ros2_control_demos example_position

--- a/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
@@ -1,0 +1,97 @@
+# Copyright 2024 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    # Launch Arguments
+    use_sim_time = LaunchConfiguration('use_sim_time', default=True)
+
+    # Get URDF via xacro
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution(
+                [FindPackageShare("gz_ros2_control_demos"),
+                 "urdf", "test_pendulum_effort.xacro.urdf"]
+            ),
+        ]
+    )
+    robot_description = {"robot_description": robot_description_content}
+
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[robot_description]
+    )
+
+    gz_spawn_entity = Node(
+        package='ros_gz_sim',
+        executable='create',
+        output='screen',
+        arguments=["-topic", "robot_description",
+                   "-name", "cart", "-allow_renaming", "true"],
+    )
+
+    load_joint_state_broadcaster = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
+             'joint_state_broadcaster'],
+        output='screen'
+    )
+
+    load_joint_effort_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller',
+             '--set-state', 'active', 'effort_controller'],
+        output='screen'
+    )
+
+    return LaunchDescription([
+        # Launch gazebo environment
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
+                                       'launch',
+                                       'gz_sim.launch.py'])]),
+            launch_arguments=[('gz_args', [' -r -v 3 empty.sdf'])]),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=gz_spawn_entity,
+                on_exit=[load_joint_state_broadcaster],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_broadcaster,
+                on_exit=[load_joint_effort_controller],
+            )
+        ),
+        node_robot_state_publisher,
+        gz_spawn_entity,
+        # Launch Arguments
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value=use_sim_time,
+            description='If true, use simulated clock'),
+    ])

--- a/gz_ros2_control_demos/launch/pendulum_example_position.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_position.launch.py
@@ -1,0 +1,97 @@
+# Copyright 2024 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    # Launch Arguments
+    use_sim_time = LaunchConfiguration('use_sim_time', default=True)
+
+    # Get URDF via xacro
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution(
+                [FindPackageShare("gz_ros2_control_demos"),
+                 "urdf", "test_pendulum_position.xacro.urdf"]
+            ),
+        ]
+    )
+    robot_description = {"robot_description": robot_description_content}
+
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[robot_description]
+    )
+
+    gz_spawn_entity = Node(
+        package='ros_gz_sim',
+        executable='create',
+        output='screen',
+        arguments=["-topic", "robot_description",
+                   "-name", "cart", "-allow_renaming", "true"],
+    )
+
+    load_joint_state_broadcaster = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
+             'joint_state_broadcaster'],
+        output='screen'
+    )
+
+    load_joint_trajectory_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
+             'joint_trajectory_controller'],
+        output='screen'
+    )
+
+    return LaunchDescription([
+        # Launch gazebo environment
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
+                                       'launch',
+                                       'gz_sim.launch.py'])]),
+            launch_arguments=[('gz_args', [' -r -v 4 empty.sdf'])]),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=gz_spawn_entity,
+                on_exit=[load_joint_state_broadcaster],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_broadcaster,
+                on_exit=[load_joint_trajectory_controller],
+            )
+        ),
+        node_robot_state_publisher,
+        gz_spawn_entity,
+        # Launch Arguments
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value=use_sim_time,
+            description='If true, use simulated clock'),
+    ])

--- a/gz_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="pendulum on cart">
+
+  <xacro:macro name="quadr_block" params="mass width height name">
+    <link name="${name}">
+      <collision>
+        <geometry>
+          <box size="${width} ${width} ${height}"/>
+        </geometry>
+        <origin xyz="0 0 0"/>
+      </collision>
+      <visual>
+        <geometry>
+          <box size="${width} ${width} ${height}"/>
+        </geometry>
+        <origin xyz="0 0 ${height/2}"/>
+        <material name="blue">
+          <color rgba="0 0 .8 1"/>
+        </material>
+      </visual>
+      <inertial>
+        <origin xyz="0 0 ${height/2}" rpy="0 0 0"/>
+        <mass value="${mass}"/>
+        <inertia
+          ixx="${mass / 12.0 * (width*width + height*height)}" ixy="0.0" ixz="0.0"
+          iyy="${mass / 12.0 * (height*height + width*width)}" iyz="0.0"
+          izz="${mass / 12.0 * (width*width + width*width)}"/>
+      </inertial>
+    </link>
+  </xacro:macro>
+
+  <link name="world"/>
+
+  <link name="slideBar">
+    <visual>
+      <geometry>
+        <box size="30 0.05 0.05"/>
+      </geometry>
+      <origin xyz="0 0 0"/>
+      <material name="green">
+        <color rgba="0 0.8 .8 1"/>
+      </material>
+    </visual>
+    <inertial>
+      <mass value="100"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+    </inertial>
+  </link>
+
+  <xacro:quadr_block name="cart" mass="10" width="0.5" height="0.2"/>
+
+  <xacro:quadr_block name="pendulum" mass="1" width="0.2" height="1.0"/>
+
+  <joint name="world_to_base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 1"/>
+    <parent link="world"/>
+    <child link="slideBar"/>
+  </joint>
+
+  <joint name="slider_to_cart" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <origin xyz="0.0 0.0 0.0"/>
+    <parent link="slideBar"/>
+    <child link="cart"/>
+    <limit effort="1000.0" lower="-15" upper="15" velocity="30"/>
+    <dynamics damping="0.3" friction="0.0"/>
+  </joint>
+
+  <joint name="cart_to_pendulum" type="revolute">
+    <axis xyz="0 1 0"/>
+    <origin xyz="0.0 0.35 0.0" rpy="0 0.1 0"/>
+    <parent link="cart"/>
+    <child link="pendulum"/>
+    <limit effort="10000.0" lower="-100000" upper="100000" velocity="100000"/>
+    <dynamics damping="0.1" friction="0.0"/>
+  </joint>
+
+  <ros2_control name="GazeboSystem" type="system">
+    <hardware>
+      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+    </hardware>
+    <joint name="slider_to_cart">
+      <command_interface name="effort">
+        <param name="min">-1000</param>
+        <param name="max">1000</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">1.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="cart_to_pendulum">
+      <state_interface name="position">
+        <!-- this does not work if no command interface is set -->
+        <!-- <param name="initial_value">1.57</param> -->
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+  </ros2_control>
+
+  <gazebo>
+    <!-- Joint state publisher -->
+    <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+      <parameters>$(find gz_ros2_control_demos)/config/cart_controller_effort.yaml</parameters>
+    </plugin>
+  </gazebo>
+</robot>

--- a/gz_ros2_control_demos/urdf/test_pendulum_position.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_pendulum_position.xacro.urdf
@@ -1,0 +1,105 @@
+<?xml version="1.0" ?>
+<robot name="cartopole">
+  <link name="world"/>
+  <link name="slideBar">
+    <visual>
+      <geometry>
+        <box size="30 0.05 0.05"/>
+      </geometry>
+      <origin xyz="0 0 0"/>
+      <material name="green">
+        <color rgba="0 0.8 .8 1"/>
+      </material>
+    </visual>
+    <inertial>
+      <mass value="100"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+    </inertial>
+  </link>
+  <link name="cart">
+    <visual>
+      <geometry>
+        <box size="0.5 0.5 0.2"/>
+      </geometry>
+      <origin xyz="0 0 0"/>
+      <material name="blue">
+        <color rgba="0 0 .8 1"/>
+      </material>
+    </visual>
+    <inertial>
+      <mass value="10"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+    </inertial>
+  </link>
+
+  <link name="pendulum">
+    <visual>
+      <geometry>
+        <box size="0.2 0.2 1.0"/>
+      </geometry>
+      <origin xyz="0 0 -0.4"/>
+      <material name="blue">
+        <color rgba="0 0 .8 1"/>
+      </material>
+    </visual>
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+      <origin xyz="0 0 -0.4"/>
+    </inertial>
+  </link>
+
+  <joint name="world_to_base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 1"/>
+    <parent link="world"/>
+    <child link="slideBar"/>
+  </joint>
+  <joint name="slider_to_cart" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <origin xyz="0.0 0.0 0.0"/>
+    <parent link="slideBar"/>
+    <child link="cart"/>
+    <limit effort="1000.0" lower="-15" upper="15" velocity="30"/>
+    <dynamics damping="0.0" friction="0.0"/>
+  </joint>
+  <joint name="cart_to_pendulum" type="revolute">
+    <axis xyz="0 1 0"/>
+    <origin xyz="0.0 0.35 0.0"/>
+    <parent link="cart"/>
+    <child link="pendulum"/>
+    <limit effort="1000.0" lower="-10000" upper="10000" velocity="30"/>
+    <dynamics damping="0.1" friction="0.1"/>
+  </joint>
+
+  <ros2_control name="GazeboSystem" type="system">
+    <hardware>
+      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+    </hardware>
+    <joint name="slider_to_cart">
+      <command_interface name="position">
+        <param name="min">-15</param>
+        <param name="max">15</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">1.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+    <joint name="cart_to_pendulum">
+      <state_interface name="position">
+        <!-- this does not work if no command interface is set -->
+        <!-- <param name="initial_value">1.57</param> -->
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+  </ros2_control>
+
+  <gazebo>
+    <!-- Joint state publisher -->
+    <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+      <parameters>$(find gz_ros2_control_demos)/config/cart_controller_position.yaml</parameters>
+    </plugin>
+  </gazebo>
+</robot>


### PR DESCRIPTION
Similar to https://github.com/ros-controls/gazebo_ros2_control/pull/172

The difference to gazebo_ros2_control is that it also works with position command interface of the cart. gz_ros2_control does not directly set the position but implements a position controller with velocity output:
https://github.com/ros-controls/gz_ros2_control/blob/81dca7171ba6fab0dd9631a7e815f0b312cddc81/gz_ros2_control/src/gz_system.cpp#L632-L651

