### PR TITLE
Fixed target of ament_export_libraries

### DIFF
--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -109,7 +109,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME} gz_hardware_plugins)
+ament_export_libraries(${PROJECT_NAME}-system gz_hardware_plugins)
 
 # Install directories
 install(TARGETS ${PROJECT_NAME}-system


### PR DESCRIPTION
Since a non-existent library was specified for export, a warning was generated as shown below when building packages that depend on gz_ros2_control.

```
CMake Warning at /home/ubuntu/ws_gz_ros2_control/install/gz_ros2_control/share/gz_ros2_control/cmake/ament_cmake_export_libraries-extras.cmake:116 (message):
  Package 'gz_ros2_control' exports library 'gz_ros2_control' which couldn't
  be found
Call Stack (most recent call first):
  /home/ubuntu/ws_gz_ros2_control/install/gz_ros2_control/share/gz_ros2_control/cmake/gz_ros2_controlConfig.cmake:41 (include)
  CMakeLists.txt:49 (find_package)
```

 This pull request changes it to export the correct existing target.