### PR TITLE
[backport Humble] Fixed target of ament_export_libraries

### DIFF
--- a/ign_ros2_control/CMakeLists.txt
+++ b/ign_ros2_control/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME} ign_hardware_plugins)
+ament_export_libraries(${PROJECT_NAME}-system ign_hardware_plugins)
 
 # Install directories
 install(TARGETS ${PROJECT_NAME}-system


### PR DESCRIPTION
Related to https://github.com/ros-controls/gz_ros2_control/pull/295