### PR TITLE
[CI] Update branch of reusable workflow

### DIFF
--- a/.github/workflows/ci-check-docs.yml
+++ b/.github/workflows/ci-check-docs.yml
@@ -7,6 +7,6 @@ on:
 jobs:
   check-docs:
     name: Check Docs
-    uses: ros-controls/control.ros.org/.github/workflows/reusable-sphinx-check-single-version.yml@master
+    uses: ros-controls/control.ros.org/.github/workflows/reusable-sphinx-check-single-version.yml@rolling
     with:
       GZ_ROS2_CONTROL_PR: ${{ github.ref }}


### PR DESCRIPTION
Since https://github.com/ros-controls/control.ros.org/pull/293 we need to specify `rolling` instead of `master` for the reusable workflow. 