### PR TITLE
Remove stamped twist parameter

### DIFF
--- a/gz_ros2_control_demos/config/diff_drive_controller_velocity.yaml
+++ b/gz_ros2_control_demos/config/diff_drive_controller_velocity.yaml
@@ -32,7 +32,6 @@ diff_drive_base_controller:
 
     cmd_vel_timeout: 0.5
     #publish_limited_velocity: true
-    use_stamped_vel: true
     #velocity_rolling_window_size: 10
 
     # Velocity and acceleration limits

--- a/gz_ros2_control_demos/config/tricycle_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/tricycle_drive_controller.yaml
@@ -50,7 +50,6 @@ tricycle_controller:
 
     # cmd_vel input
     cmd_vel_timeout: 500 # In milliseconds. Timeout to stop if no cmd_vel is received
-    use_stamped_vel: true # Set to True if using TwistStamped.
 
     # Debug
     publish_ackermann_command: true # Publishes AckermannDrive. The speed does not comply to the msg definition, it the wheel angular speed in rad/s.


### PR DESCRIPTION
Is default true already, and will be removed by https://github.com/ros-controls/ros2_controllers/pull/1151 