### PR TITLE
diff drive example missing colors

### DIFF
--- a/gz_ros2_control_demos/urdf/test_diff_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_diff_drive.xacro.urdf
@@ -1,5 +1,16 @@
 <?xml version="1.0"?>
 <robot name="diff_drive" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <material name="orange">
+    <color rgba="0.8 0.4 0.0 1.0"/>
+  </material>
+
+  <material name="black">
+    <color rgba="0 0 0 1.0"/>
+  </material>
+
+  <material name="white">
+    <color rgba="1 1 1 1.0"/>
+  </material>
   <!-- Base Link -->
   <link name="chassis">
     <collision>


### PR DESCRIPTION
when running `ros2 launch gz_ros2_control_demos diff_drive_example.launch.py` the following errors are seen:

```
[robot_state_publisher-2] Warning: link 'chassis' material 'orange' undefined.
[robot_state_publisher-2]          at line 85 in ./urdf_parser/src/model.cpp
[robot_state_publisher-2] Warning: link 'chassis' material 'orange' undefined.
[robot_state_publisher-2]          at line 85 in ./urdf_parser/src/model.cpp
[robot_state_publisher-2] Warning: link 'left_wheel' material 'black' undefined.
[robot_state_publisher-2]          at line 85 in ./urdf_parser/src/model.cpp
[robot_state_publisher-2] Warning: link 'left_wheel' material 'black' undefined.
[robot_state_publisher-2]          at line 85 in ./urdf_parser/src/model.cpp
[robot_state_publisher-2] Warning: link 'right_wheel' material 'black' undefined.
[robot_state_publisher-2]          at line 85 in ./urdf_parser/src/model.cpp
[robot_state_publisher-2] Warning: link 'right_wheel' material 'black' undefined.
[robot_state_publisher-2]          at line 85 in ./urdf_parser/src/model.cpp
[robot_state_publisher-2] Warning: link 'caster' material 'white' undefined.
[robot_state_publisher-2]          at line 85 in ./urdf_parser/src/model.cpp
[robot_state_publisher-2] Warning: link 'caster' material 'white' undefined.
[robot_state_publisher-2]          at line 85 in ./urdf_parser/src/model.cpp
```
and
```
[ruby $(which gz) sim-1] Warning: link 'chassis' material 'orange' undefined.
[ruby $(which gz) sim-1]          at line 85 in ./urdf_parser/src/model.cpp
[ruby $(which gz) sim-1] Warning: link 'chassis' material 'orange' undefined.
[ruby $(which gz) sim-1]          at line 85 in ./urdf_parser/src/model.cpp
[ruby $(which gz) sim-1] Warning: link 'left_wheel' material 'black' undefined.
[ruby $(which gz) sim-1]          at line 85 in ./urdf_parser/src/model.cpp
[ruby $(which gz) sim-1] Warning: link 'left_wheel' material 'black' undefined.
[ruby $(which gz) sim-1]          at line 85 in ./urdf_parser/src/model.cpp
[ruby $(which gz) sim-1] Warning: link 'right_wheel' material 'black' undefined.
[ruby $(which gz) sim-1]          at line 85 in ./urdf_parser/src/model.cpp
[ruby $(which gz) sim-1] Warning: link 'right_wheel' material 'black' undefined.
[ruby $(which gz) sim-1]          at line 85 in ./urdf_parser/src/model.cpp
[ruby $(which gz) sim-1] Warning: link 'caster' material 'white' undefined.
[ruby $(which gz) sim-1]          at line 85 in ./urdf_parser/src/model.cpp
[ruby $(which gz) sim-1] Warning: link 'caster' material 'white' undefined.
[ruby $(which gz) sim-1]          at line 85 in ./urdf_parser/src/model.cpp
```

without the changes:

![Screenshot from 2024-05-28 14-40-20](https://github.com/ros-controls/gz_ros2_control/assets/22005547/1abba8dc-b13a-4522-b258-508ca04102d4)

with the changes:


![Screenshot from 2024-05-28 14-40-43](https://github.com/ros-controls/gz_ros2_control/assets/22005547/1775af72-942a-4c76-accc-9a89030f971e)
