### PR TITLE
Fix MultiThreadedExecutor spinning

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -73,9 +73,6 @@ public:
   /// \brief Thread where the executor will spin
   std::thread thread_executor_spin_;
 
-  /// \brief Flag to stop the executor thread when this plugin is exiting
-  bool stop_{false};
-
   /// \brief Executor to spin the controller
   rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_;
 
@@ -238,7 +235,6 @@ GazeboSimROS2ControlPlugin::GazeboSimROS2ControlPlugin()
 GazeboSimROS2ControlPlugin::~GazeboSimROS2ControlPlugin()
 {
   // Stop controller manager thread
-  this->dataPtr->stop_ = true;
   this->dataPtr->executor_->remove_node(this->dataPtr->controller_manager_);
   this->dataPtr->executor_->cancel();
   this->dataPtr->thread_executor_spin_.join();
@@ -364,12 +360,9 @@ void GazeboSimROS2ControlPlugin::Configure(
   this->dataPtr->node_ = rclcpp::Node::make_shared(node_name, ns);
   this->dataPtr->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   this->dataPtr->executor_->add_node(this->dataPtr->node_);
-  this->dataPtr->stop_ = false;
   auto spin = [this]()
     {
-      while (rclcpp::ok() && !this->dataPtr->stop_) {
-        this->dataPtr->executor_->spin_once();
-      }
+      this->dataPtr->executor_->spin();
     };
   this->dataPtr->thread_executor_spin_ = std::thread(spin);
 


### PR DESCRIPTION
I noticed that the MultiThreadedExecutor was not operating in a multi-threaded manner, so I made some changes.

From my review of the rclcpp code, it appears that the current rclcpp::MultiThreadedExecutor only implements spin(), and spin_once() and spin_some() simply execute the implementation from the base class rclcpp::Executor.

Implementation of MultiThreadedExecutor::spin():
- https://github.com/ros2/rclcpp/blob/0beba9715675e06bf63f041fd1046b2f23d3b3ce/rclcpp/include/rclcpp/executors/multi_threaded_executor.hpp#L69-L70
- https://github.com/ros2/rclcpp/blob/0beba9715675e06bf63f041fd1046b2f23d3b3ce/rclcpp/src/rclcpp/executors/multi_threaded_executor.cpp#L53-L73

Even after checking the implementation of rclcpp::Executor, I found no instances where the overridden spin is utilized. As a result, spin_once() and spin_some() seem to operate in a single-threaded mode. Indeed, in the header file of rclcpp::Executor, spin_some() and spin_once() are described as "suitable for a single-threaded model of execution."
- https://github.com/ros2/rclcpp/blob/0beba9715675e06bf63f041fd1046b2f23d3b3ce/rclcpp/include/rclcpp/executor.hpp#L286
- https://github.com/ros2/rclcpp/blob/0beba9715675e06bf63f041fd1046b2f23d3b3ce/rclcpp/include/rclcpp/executor.hpp#L342-L343

Additionally, similar observations were made in a related pull request for rclcpp.
https://github.com/ros2/rclcpp/pull/2454

There was also an old issue related to this problem, but it seems to have been closed without appropriate changes.
https://github.com/ros2/rclcpp/issues/85

Therefore, in this pull request, I changed the implementation to use spin() instead of spin_once() for MultiThreadedExecutor. Consequently, the stop_ flag became unnecessary and was removed. It has been confirmed that the spin thread terminates correctly with [executor_->cancel()](https://github.com/TakashiSato/gz_ros2_control/commit/741540417fcd0703790ed5f254f8b23b2a6cd41d#diff-bca9461c5596d60dd1b8407df53208db932c5f5d64f5d4fdfa2225dbd1ad2ac1L243-L244), without using the stop_ flag.

As a side note, I would like to mention that MultiThreadedExecutor::spin() is also used in the [ros2_control_node](https://github.com/ros-controls/ros2_control/blob/2cbe47016ae6727358f2831b540513e661bd7980/controller_manager/src/ros2_control_node.cpp#L91).