### PR TITLE
Don't crash if a wrong config was detected

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -235,6 +235,9 @@ GazeboSimROS2ControlPlugin::GazeboSimROS2ControlPlugin()
 GazeboSimROS2ControlPlugin::~GazeboSimROS2ControlPlugin()
 {
   // Stop controller manager thread
+  if (!this->dataPtr->controller_manager_) {
+    return;
+  }
   this->dataPtr->executor_->remove_node(this->dataPtr->controller_manager_);
   this->dataPtr->executor_->cancel();
   this->dataPtr->thread_executor_spin_.join();
@@ -514,6 +517,9 @@ void GazeboSimROS2ControlPlugin::PreUpdate(
   const sim::UpdateInfo & _info,
   sim::EntityComponentManager & /*_ecm*/)
 {
+  if (!this->dataPtr->controller_manager_) {
+    return;
+  }
   static bool warned{false};
   if (!warned) {
     rclcpp::Duration gazebo_period(_info.dt);
@@ -548,6 +554,9 @@ void GazeboSimROS2ControlPlugin::PostUpdate(
   const sim::UpdateInfo & _info,
   const sim::EntityComponentManager & /*_ecm*/)
 {
+  if (!this->dataPtr->controller_manager_) {
+    return;
+  }
   // Get the simulation time and period
   rclcpp::Time sim_time_ros(std::chrono::duration_cast<std::chrono::nanoseconds>(
       _info.simTime).count(), RCL_ROS_TIME);


### PR DESCRIPTION
As reported with #323, the plugin crashes if there is a wrong config. On humble, the controller_manager tries to access unavailable state interfaces (I'll investigate more).

But also on rolling it crashes, despite the URDF parsers throws an error if a joint does not exists. The `configure()` method returns but `PreUpdate`, `PostUpdate` and `Deconstructor` are accessing the `this->dataPtr->controller_manager_`
https://github.com/ros-controls/gz_ros2_control/blob/45035076408e6014cc911e8d4bc169572a25008c/gz_ros2_control/src/gz_ros2_control_plugin.cpp#L394-L397

Is there maybe another way to deactivate the plugin properly and not even call the Update methods?