### PR TITLE
Harden behavior if a joint is not found in the model (backport #325)

### DIFF
--- a/ign_ros2_control/src/ign_system.cpp
+++ b/ign_ros2_control/src/ign_system.cpp
@@ -204,6 +204,14 @@ bool IgnitionSystem::initSim(
     auto & joint_info = hardware_info.joints[j];
     std::string joint_name = this->dataPtr->joints_[j].name = joint_info.name;
 
+    auto it = enableJoints.find(joint_name);
+    if (it == enableJoints.end()) {
+      RCLCPP_WARN_STREAM(
+        this->nh_->get_logger(), "Skipping joint in the URDF named '" << joint_name <<
+          "' which is not in the gazebo model.");
+      continue;
+    }
+
     ignition::gazebo::Entity simjoint = enableJoints[joint_name];
     this->dataPtr->joints_[j].sim_joint = simjoint;
 
@@ -521,6 +529,10 @@ hardware_interface::return_type IgnitionSystem::read(
   const rclcpp::Duration & /*period*/)
 {
   for (unsigned int i = 0; i < this->dataPtr->joints_.size(); ++i) {
+    if(this->dataPtr->joints_[i].sim_joint == ignition::gazebo::v6::kNullEntity) {
+      continue;
+    }
+
     // Get the joint velocity
     const auto * jointVelocity =
       this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocity>(
@@ -613,6 +625,11 @@ hardware_interface::return_type IgnitionSystem::write(
   const rclcpp::Duration & /*period*/)
 {
   for (unsigned int i = 0; i < this->dataPtr->joints_.size(); ++i) {
+
+    if(this->dataPtr->joints_[i].sim_joint == ignition::gazebo::v6::kNullEntity) {
+      continue;
+    }
+    
     if (this->dataPtr->joints_[i].joint_control_method & VELOCITY) {
       if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityCmd>(
           this->dataPtr->joints_[i].sim_joint))

--- a/ign_ros2_control/src/ign_system.cpp
+++ b/ign_ros2_control/src/ign_system.cpp
@@ -529,7 +529,7 @@ hardware_interface::return_type IgnitionSystem::read(
   const rclcpp::Duration & /*period*/)
 {
   for (unsigned int i = 0; i < this->dataPtr->joints_.size(); ++i) {
-    if(this->dataPtr->joints_[i].sim_joint == ignition::gazebo::v6::kNullEntity) {
+    if (this->dataPtr->joints_[i].sim_joint == ignition::gazebo::v6::kNullEntity) {
       continue;
     }
 
@@ -625,11 +625,10 @@ hardware_interface::return_type IgnitionSystem::write(
   const rclcpp::Duration & /*period*/)
 {
   for (unsigned int i = 0; i < this->dataPtr->joints_.size(); ++i) {
-
-    if(this->dataPtr->joints_[i].sim_joint == ignition::gazebo::v6::kNullEntity) {
+    if (this->dataPtr->joints_[i].sim_joint == ignition::gazebo::v6::kNullEntity) {
       continue;
     }
-    
+
     if (this->dataPtr->joints_[i].joint_control_method & VELOCITY) {
       if (!this->dataPtr->ecm->Component<ignition::gazebo::components::JointVelocityCmd>(
           this->dataPtr->joints_[i].sim_joint))


### PR DESCRIPTION
As reported with https://github.com/ros-controls/gz_ros2_control/issues/323, the plugin crashes if there is a wrong config.

I suggest skipping if it the joint is not in the `enableJoints` map.

This is a manual backport, because of the changed namespaces.