### PR TITLE
Changed command for gui launch to gz instead of ign

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,7 +37,7 @@ To run the demo
 
   .. code-block:: shell
 
-    ign gazebo -g
+    gz sim -g
 
 
 2. Using Rocker


### PR DESCRIPTION
As per the gazebo doc, Fortress and Citadel use "ign gazebo" while newer versions use "gz sim"