### PR TITLE
Ackermann steering example

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -244,6 +244,7 @@ You can run some of the mobile robots running the following commands:
 
   ros2 launch gz_ros2_control_demos diff_drive_example.launch.py
   ros2 launch gz_ros2_control_demos tricycle_drive_example.launch.py
+  ros2 launch gz_ros2_control_demos ackermann_drive_example.launch.py
 
 When the Gazebo world is launched you can run some of the following commands to move the robots.
 
@@ -251,6 +252,7 @@ When the Gazebo world is launched you can run some of the following commands to 
 
   ros2 run gz_ros2_control_demos example_diff_drive
   ros2 run gz_ros2_control_demos example_tricycle_drive
+  ros2 run gz_ros2_control_demos example_ackermann_drive
 
 Gripper
 -----------------------------------------------------------

--- a/gz_ros2_control_demos/CMakeLists.txt
+++ b/gz_ros2_control_demos/CMakeLists.txt
@@ -60,6 +60,12 @@ ament_target_dependencies(example_tricycle_drive
   geometry_msgs
 )
 
+add_executable(example_ackermann_drive examples/example_ackermann_drive.cpp)
+ament_target_dependencies(example_ackermann_drive
+  rclcpp
+  geometry_msgs
+)
+
 add_executable(example_gripper examples/example_gripper.cpp)
 ament_target_dependencies(example_gripper
   rclcpp
@@ -81,6 +87,7 @@ install(
     example_effort
     example_diff_drive
     example_tricycle_drive
+    example_ackermann_drive
     example_gripper
   DESTINATION
     lib/${PROJECT_NAME}

--- a/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
@@ -1,15 +1,15 @@
 controller_manager:
   ros__parameters:
     update_rate: 10  # Hz
-      
+
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
-    
+
 
     ackermann_steering_controller:
       type: 'ackermann_steering_controller/AckermannSteeringController'
 
-    
+
 
 ackermann_steering_controller:
   ros__parameters:

--- a/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
@@ -1,0 +1,32 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 10  # Hz
+      
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+    
+
+    ackermann_steering_controller:
+      type: 'ackermann_steering_controller/AckermannSteeringController'
+
+    
+
+ackermann_steering_controller:
+  ros__parameters:
+    wheelbase: 1.7
+    front_wheel_track: 1.0
+    rear_wheel_track: 1.0
+    front_wheels_radius: 0.3
+    rear_wheels_radius: 0.3
+    front_steering: true
+    reference_timeout: 2.0
+    rear_wheels_names: ['rear_left_wheel_joint', 'rear_right_wheel_joint']
+    front_wheels_names: ['left_wheel_steering_joint', 'right_wheel_steering_joint']
+    open_loop: false
+    velocity_rolling_window_size: 10
+    base_frame_id: base_link
+    odom_frame_id: odom
+    enable_odom_tf: true
+    twist_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
+    pose_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
+    position_feedback: false

--- a/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
@@ -9,8 +9,6 @@ controller_manager:
     ackermann_steering_controller:
       type: 'ackermann_steering_controller/AckermannSteeringController'
 
-
-
 ackermann_steering_controller:
   ros__parameters:
     wheelbase: 1.7

--- a/gz_ros2_control_demos/examples/example_ackermann_drive.cpp
+++ b/gz_ros2_control_demos/examples/example_ackermann_drive.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Open Source Robotics Foundation, Inc.
+// Copyright 2024 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/gz_ros2_control_demos/examples/example_ackermann_drive.cpp
+++ b/gz_ros2_control_demos/examples/example_ackermann_drive.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 
 #include <rclcpp/rclcpp.hpp>

--- a/gz_ros2_control_demos/examples/example_ackermann_drive.cpp
+++ b/gz_ros2_control_demos/examples/example_ackermann_drive.cpp
@@ -1,0 +1,53 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/twist.hpp>
+
+using namespace std::chrono_literals;
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  std::shared_ptr<rclcpp::Node> node =
+    std::make_shared<rclcpp::Node>("ackermann_drive_test_node");
+
+  auto publisher = node->create_publisher<geometry_msgs::msg::Twist>(
+    "/ackermann_steering_controller/reference_unstamped", 10);
+
+  RCLCPP_INFO(node->get_logger(), "node created");
+
+  geometry_msgs::msg::Twist command;
+
+  command.linear.x = 0.5;
+  command.linear.y = 0.0;
+  command.linear.z = 0.0;
+
+  command.angular.x = 0.0;
+  command.angular.y = 0.0;
+  command.angular.z = 0.3;
+
+  while (1) {
+    publisher->publish(command);
+    std::this_thread::sleep_for(50ms);
+    rclcpp::spin_some(node);
+  }
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
@@ -1,0 +1,106 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    # Launch Arguments
+    use_sim_time = LaunchConfiguration('use_sim_time', default=True)
+
+    # Get URDF via xacro
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name='xacro')]),
+            ' ',
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'urdf', 'test_ackermann_drive.xacro.urdf']
+            ),
+        ]
+    )
+    robot_description = {'robot_description': robot_description_content}
+
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[robot_description]
+    )
+
+    gz_spawn_entity = Node(
+        package='ros_gz_sim',
+        executable='create',
+        output='screen',
+        arguments=['-topic', 'robot_description', '-name',
+                   'ackermann', '-allow_renaming', 'true'],
+    )
+
+    load_joint_state_broadcaster = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
+             'joint_state_broadcaster'],
+        output='screen'
+    )
+
+    load_ackermann_controller = ExecuteProcess(
+        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
+             'ackermann_steering_controller'],
+        output='screen'
+    )
+
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
+    return LaunchDescription([
+        bridge,
+        # Launch gazebo environment
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
+                                       'launch',
+                                       'gz_sim.launch.py'])]),
+            launch_arguments=[('gz_args', [' -r -v 4 empty.sdf'])]),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=gz_spawn_entity,
+                on_exit=[load_joint_state_broadcaster],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=load_joint_state_broadcaster,
+                on_exit=[load_ackermann_controller],
+            )
+        ),
+        node_robot_state_publisher,
+        gz_spawn_entity,
+        # Launch Arguments
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value=use_sim_time,
+            description='If true, use simulated clock'),
+    ])

--- a/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -43,6 +43,7 @@
   <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>
   <exec_depend>tricycle_controller</exec_depend>
+  <exec_depend>ackermann_steering_controller</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -102,6 +102,10 @@
 
   <!-- left steer Link -->
   <link name="left_wheel_steering">
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0" />
+    </inertial>
   </link>
 
   <joint name="left_wheel_steering_joint" type="continuous">
@@ -114,6 +118,10 @@
 
   <!-- right steer Link -->
   <link name="right_wheel_steering">
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0" />
+    </inertial>
   </link>
 
   <joint name="right_wheel_steering_joint" type="continuous">

--- a/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -152,7 +152,6 @@
   </link>
 
   <joint name="front_left_wheel_joint" type="continuous">
-    <mimic joint="rear_left_wheel_joint"/>
     <origin xyz="0 0 0" rpy="0 0 0" />
     <parent link="left_wheel_steering" />
     <child link="front_left_wheel" />
@@ -180,7 +179,6 @@
   </link>
 
   <joint name="front_right_wheel_joint" type="continuous">
-    <mimic joint="rear_right_wheel_joint"/>
     <origin xyz="0 0 0" rpy="0 0 0" />
     <parent link="right_wheel_steering" />
     <child link="front_right_wheel" />
@@ -209,14 +207,6 @@
     </joint>
     <joint name="right_wheel_steering_joint">
       <command_interface name="position" />
-      <state_interface name="position" />
-    </joint>
-    <joint name="front_right_wheel_joint">
-      <state_interface name="velocity" />
-      <state_interface name="position" />
-    </joint>
-    <joint name="front_left_wheel_joint">
-      <state_interface name="velocity" />
       <state_interface name="position" />
     </joint>
   </ros2_control>

--- a/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -186,7 +186,6 @@
     <dynamics damping="0.2" />
   </joint>
 
-
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
       <plugin>gz_ros2_control/GazeboSimSystem</plugin>

--- a/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -1,0 +1,222 @@
+<?xml version="1.0"?>
+<robot name="tricycle_drive" xmlns:xacro="http://ros.org/wiki/xacro">
+  <material name="Black">
+    <color rgba="0 0 0 1" />
+  </material>
+  <material name="Grey">
+    <color rgba="0.8 0.8 0.8 1" />
+  </material>
+  <material name="Orange">
+    <color rgba="1 0.6 0 1" />
+  </material>
+  <material name="White">
+    <color rgba="1 1 1 1" />
+  </material>
+
+  <link name="base_link" />
+
+  <!-- Chassis -->
+  <link name="chassis">
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <box size="2 1 0.5" />
+      </geometry>
+    </collision>
+
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <box size="2 1 0.5" />
+      </geometry>
+      <material name="Orange" />
+    </visual>
+
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <mass value="1" />
+      <inertia ixx="0.126164" ixy="0.0" ixz="0.0" iyy="0.416519" iyz="0.0" izz="0.481014" />
+    </inertial>
+  </link>
+
+  <joint name="chassis_joint" type="fixed">
+    <origin xyz="0.8 0 0.5" rpy="0 0 0" />
+    <parent link="base_link" />
+    <child link="chassis" />
+  </joint>
+
+  <!-- rear left wheel Link -->
+  <link name="rear_left_wheel">
+    <collision>
+      <geometry>
+        <cylinder length="0.08" radius="0.3" />
+      </geometry>
+    </collision>
+    <visual>
+      <geometry>
+        <cylinder length="0.08" radius="0.3" />
+      </geometry>
+      <material name="Black" />
+    </visual>
+
+    <inertial>
+      <mass value="2" />
+      <inertia ixx="0.145833" ixy="0.0" ixz="0.0" iyy="0.145833" iyz="0.0" izz="0.125" />
+    </inertial>
+  </link>
+
+  <joint name="rear_left_wheel_joint" type="continuous">
+    <origin xyz="-0.8 0.5 -0.2" rpy="-1.57 0 0" />
+    <parent link="chassis" />
+    <child link="rear_left_wheel" />
+    <axis xyz="0 0 1" />
+    <dynamics damping="0.2" />
+  </joint>
+
+  <!-- rear right wheel Link -->
+  <link name="rear_right_wheel">
+    <collision>
+      <geometry>
+        <cylinder length="0.08" radius="0.3" />
+      </geometry>
+    </collision>
+    <visual>
+      <geometry>
+        <cylinder length="0.08" radius="0.3" />
+      </geometry>
+      <material name="Black" />
+    </visual>
+    <inertial>
+      <mass value="2" />
+      <inertia ixx="0.145833" ixy="0.0" ixz="0.0" iyy="0.145833" iyz="0.0" izz="0.125" />
+    </inertial>
+  </link>
+
+  <joint name="rear_right_wheel_joint" type="continuous">
+    <origin xyz="-0.8 -0.5 -0.2" rpy="-1.57 0 0" />
+    <parent link="chassis" />
+    <child link="rear_right_wheel" />
+    <axis xyz="0 0 1" />
+    <dynamics damping="0.2" />
+  </joint>
+
+  <!-- left steer Link -->
+  <link name="left_wheel_steering">
+  </link>
+
+  <joint name="left_wheel_steering_joint" type="continuous">
+    <origin xyz="0.9 0.5 -0.2" rpy="-1.57 0 0" />
+    <parent link="chassis" />
+    <child link="left_wheel_steering" />
+    <axis xyz="0 1 0" />
+    <dynamics damping="0.2" />
+  </joint>
+
+  <!-- right steer Link -->
+  <link name="right_wheel_steering">
+  </link>
+
+  <joint name="right_wheel_steering_joint" type="continuous">
+    <origin xyz="0.9 -0.5 -0.2" rpy="-1.57 0 0" />
+    <parent link="chassis" />
+    <child link="right_wheel_steering" />
+    <axis xyz="0 1 0" />
+    <dynamics damping="0.2" />
+  </joint>
+
+  <!-- front left wheel Link -->
+  <link name="front_left_wheel">
+    <collision>
+      <geometry>
+        <cylinder length="0.08" radius="0.3" />
+      </geometry>
+    </collision>
+    <visual>
+      <geometry>
+        <cylinder length="0.08" radius="0.3" />
+      </geometry>
+      <material name="Black" />
+    </visual>
+    <inertial>
+      <mass value="2" />
+      <inertia ixx="0.145833" ixy="0.0" ixz="0.0" iyy="0.145833" iyz="0.0" izz="0.125" />
+    </inertial>
+  </link>
+
+  <joint name="front_left_wheel_joint" type="continuous">
+    <mimic joint="rear_left_wheel_joint"/>
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <parent link="left_wheel_steering" />
+    <child link="front_left_wheel" />
+    <axis xyz="0 0 1" />
+    <dynamics damping="0.2" />
+  </joint>
+
+  <!-- front right wheel Link -->
+  <link name="front_right_wheel">
+    <collision>
+      <geometry>
+        <cylinder length="0.08" radius="0.3" />
+      </geometry>
+    </collision>
+    <visual>
+      <geometry>
+        <cylinder length="0.08" radius="0.3" />
+      </geometry>
+      <material name="Black" />
+    </visual>
+    <inertial>
+      <mass value="2" />
+      <inertia ixx="0.145833" ixy="0.0" ixz="0.0" iyy="0.145833" iyz="0.0" izz="0.125" />
+    </inertial>
+  </link>
+
+  <joint name="front_right_wheel_joint" type="continuous">
+    <mimic joint="rear_right_wheel_joint"/>
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <parent link="right_wheel_steering" />
+    <child link="front_right_wheel" />
+    <axis xyz="0 0 1" />
+    <dynamics damping="0.2" />
+  </joint>
+
+
+  <ros2_control name="GazeboSystem" type="system">
+    <hardware>
+      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+    </hardware>
+    <joint name="rear_left_wheel_joint">
+      <command_interface name="velocity" />
+      <state_interface name="velocity" />
+      <state_interface name="position" />
+    </joint>
+    <joint name="rear_right_wheel_joint">
+      <command_interface name="velocity" />
+      <state_interface name="velocity" />
+      <state_interface name="position" />
+    </joint>
+    <joint name="left_wheel_steering_joint">
+      <command_interface name="position" />
+      <state_interface name="position" />
+    </joint>
+    <joint name="right_wheel_steering_joint">
+      <command_interface name="position" />
+      <state_interface name="position" />
+    </joint>
+    <joint name="front_right_wheel_joint">
+      <state_interface name="velocity" />
+      <state_interface name="position" />
+    </joint>
+    <joint name="front_left_wheel_joint">
+      <state_interface name="velocity" />
+      <state_interface name="position" />
+    </joint>
+  </ros2_control>
+
+  <gazebo>
+    <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+      <parameters>$(find gz_ros2_control_demos)/config/ackermann_drive_controller.yaml</parameters>
+    </plugin>
+  </gazebo>
+
+</robot>


### PR DESCRIPTION
Inspired by the diff_drive and tricycle_drive examples, created an ackermann drive example. 

This example utilizes the [ackermann_steering_controller](https://control.ros.org/rolling/doc/ros2_controllers/ackermann_steering_controller/doc/userdoc.html#ackermann-steering-controller-userdoc) from the [steering_controllers_library](https://control.ros.org/rolling/doc/ros2_controllers/steering_controllers_library/doc/userdoc.html). Its implementation is similar to the [carlikebot example](https://github.com/ros-controls/ros2_control_demos/tree/master/example_11) from ros2_control_demos. 

Parameters for the controller are the default steering controller library parameters; rear_wheels_names and front_wheels_names. The steering (front in this example) wheels reference the steering joints and the rear wheels are just the drive wheels in the urdf.

The front drive wheels are linked to the steering joints for steering and mimic the rear wheels for drive. 

The example can be brought up by running:
`ros2 launch gz_ros2_control_demos ackermann_drive_example.launch.py`

and to view it moving, the following command should be run:
`ros2 launch gz_ros2_control_demos example_ackermann_drive`
