### PR TITLE
Update docs and cleanup member of `GazeboSimROS2ControlPluginPrivate`

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -150,7 +150,7 @@ Additionally, one can add a section for namespaces and remapping rules, which wi
 .. code-block:: xml
 
   <gazebo>
-    <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+    <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
       ...
       <ros>
         <namespace>my_namespace</namespace>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -142,10 +142,7 @@ The *gz_ros2_control* ``<plugin>`` tag also has the following optional child ele
 * ``<hold_joints>``: if set to true (default), it will hold the joints' position if their interface was not claimed, e.g., the controller hasn't been activated yet.
 * ``<controller_manager_name>``: Set controller manager name (default: ``controller_manager``)
 
-Additionally, one can add a section for namespaces and remapping rules, which will be forwarded to the controller_manager and loaded controllers.
-
-
-Additionally, one can add a section for namespaces and remapping rules, which will be forwarded to the controller_manager and loaded controllers. Add the following <ros> section inside the <gazebo> tag:
+Additionally, one can specify a namespace and remapping rules, which will be forwarded to the controller_manager and loaded controllers. Add the following ``<ros>`` section:
 
 .. code-block:: xml
 
@@ -154,7 +151,7 @@ Additionally, one can add a section for namespaces and remapping rules, which wi
       ...
       <ros>
         <namespace>my_namespace</namespace>
-        <remapping>/robot_description:=/robot_description_ful</remapping>
+        <remapping>/robot_description:=/robot_description_full</remapping>
       </ros>
     </plugin>
   </gazebo>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -131,24 +131,33 @@ robot hardware interfaces between *ros2_control* and Gazebo.
 .. code-block:: xml
 
   <gazebo>
-      <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
-        <parameters>$(find gz_ros2_control_demos)/config/cart_controller.yaml</parameters>
-      </plugin>
+    <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
+      <parameters>$(find gz_ros2_control_demos)/config/cart_controller.yaml</parameters>
+    </plugin>
   </gazebo>
 
 The *gz_ros2_control* ``<plugin>`` tag also has the following optional child elements:
 
-* ``<parameters>``: YAML file with the configuration of the controllers
+* ``<parameters>``: A YAML file with the configuration of the controllers. This element can be given multiple times to load multiple files.
 * ``<hold_joints>``: if set to true (default), it will hold the joints' position if their interface was not claimed, e.g., the controller hasn't been activated yet.
+* ``<controller_manager_name>``: Set controller manager name (default: ``controller_manager``)
 
 Additionally, one can add a section for namespaces and remapping rules, which will be forwarded to the controller_manager and loaded controllers.
 
+
+Additionally, one can add a section for namespaces and remapping rules, which will be forwarded to the controller_manager and loaded controllers. Add the following <ros> section inside the <gazebo> tag:
+
 .. code-block:: xml
 
-  <ros>
-    <namespace>my_namespace</namespace>
-    <remapping>/robot_description:=/robot_description_ful</remapping>
-  </ros>
+  <gazebo>
+    <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+      ...
+      <ros>
+        <namespace>my_namespace</namespace>
+        <remapping>/robot_description:=/robot_description_ful</remapping>
+      </ros>
+    </plugin>
+  </gazebo>
 
 Default gz_ros2_control Behavior
 -----------------------------------------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -132,8 +132,6 @@ robot hardware interfaces between *ros2_control* and Gazebo.
 
   <gazebo>
       <plugin filename="libgz_ros2_control-system.so" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
-        <robot_param>robot_description</robot_param>
-        <robot_param_node>robot_state_publisher</robot_param_node>
         <parameters>$(find gz_ros2_control_demos)/config/cart_controller.yaml</parameters>
       </plugin>
   </gazebo>
@@ -142,6 +140,15 @@ The *gz_ros2_control* ``<plugin>`` tag also has the following optional child ele
 
 * ``<parameters>``: YAML file with the configuration of the controllers
 * ``<hold_joints>``: if set to true (default), it will hold the joints' position if their interface was not claimed, e.g., the controller hasn't been activated yet.
+
+Additionally, one can add a section for namespaces and remapping rules, which will be forwarded to the controller_manager and loaded controllers.
+
+.. code-block:: xml
+
+  <ros>
+    <namespace>my_namespace</namespace>
+    <remapping>/robot_description:=/robot_description_ful</remapping>
+  </ros>
 
 Default gz_ros2_control Behavior
 -----------------------------------------------------------

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -159,11 +159,6 @@ public:
   /// \brief Timing
   rclcpp::Duration control_period_ = rclcpp::Duration(1, 0);
 
-  /// \brief Interface loader
-  std::shared_ptr<pluginlib::ClassLoader<
-      gz_ros2_control::GazeboSimSystemInterface>>
-  robot_hw_sim_loader_{nullptr};
-
   /// \brief Controller manager
   std::shared_ptr<controller_manager::ControllerManager>
   controller_manager_{nullptr};


### PR DESCRIPTION
This is a follow-up to #265: Fixing the docs and removing unnecessary class variables.