### PR TITLE
Propagate the node clock and logging interface to ResourceManager

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -54,7 +54,8 @@ public:
     rclcpp::Node::SharedPtr & node,
     sim::EntityComponentManager & ecm,
     std::map<std::string, sim::Entity> enabledJoints)
-  : hardware_interface::ResourceManager(),
+  : hardware_interface::ResourceManager(
+      node->get_node_clock_interface(), node->get_node_logging_interface()),
     gz_system_loader_("gz_ros2_control", "gz_ros2_control::GazeboSimSystemInterface"),
     logger_(node->get_logger().get_child("GZResourceManager"))
   {


### PR DESCRIPTION
Needs: https://github.com/ros-controls/ros2_control/pull/1585

This changes helps to use the clock and logging interface of the node directly. We will need to backport it to Jazzy as well. 