### PR TITLE
RFC: Fixing incorrect loading of parameter files when multiple GazeboControlPlugins are used. 

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -345,13 +345,13 @@ void IgnitionROS2ControlPlugin::Configure(
   }
 
   std::vector<const char *> argv;
-  for (const auto & arg : arguments) {
-    RCLCPP_INFO(
-      logger,
-      arg.data()
-    );
-    argv.push_back(reinterpret_cast<const char *>(arg.data()));
-  }
+  // for (const auto & arg : arguments) {
+  //   RCLCPP_INFO(
+  //     logger,
+  //     arg.data()
+  //   );
+  //   argv.push_back(reinterpret_cast<const char *>(arg.data()));
+  // }
 
   // Create a default context, if not already
   if (!rclcpp::ok()) {
@@ -365,8 +365,10 @@ void IgnitionROS2ControlPlugin::Configure(
     msg.data()
   );
 
-  this->dataPtr->context_ = std::make_shared<rclcpp::Context>();
-  this->dataPtr->context_->init(static_cast<int>(argv.size()), argv.data());
+  // this->dataPtr->context_ = std::make_shared<rclcpp::Context>();
+  // this->dataPtr->context_->init(static_cast<int>(argv.size()), argv.data());
+
+  this->dataPtr->context_ = rclcpp::contexts::get_global_default_context();
 
   std::string node_name = "gz_ros2_control";
 
@@ -375,6 +377,7 @@ void IgnitionROS2ControlPlugin::Configure(
 
   rclcpp::NodeOptions node_options;
   node_options.context(this->dataPtr->context_);
+  node_options.arguments(arguments);
 
   this->dataPtr->node_ = rclcpp::Node::make_shared(node_name, ns, node_options);
   this->dataPtr->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>(executor_options);
@@ -479,6 +482,7 @@ void IgnitionROS2ControlPlugin::Configure(
 
   rclcpp::NodeOptions cm_node_options = controller_manager::get_cm_node_options();
   cm_node_options.context(this->dataPtr->context_);
+  cm_node_options.arguments(arguments);
 
   // Create the controller manager
   RCLCPP_INFO(this->dataPtr->node_->get_logger(), "Loading controller_manager");


### PR DESCRIPTION
Hi, 

I found a bug in `IgnitionROS2ControlPlugin::Configure` that prevents using multiple controller managers with varying parameter files. IMO, this is a pretty important use case for people working on multi-robot simulation.

This bug is caused because the parameter file is passed as arguments to `rclcpp::init`: 
```
// ign_ros2_control_plugin.cpp:301
  sdf::ElementPtr argument_sdf = sdfPtr->GetElement("parameters");
  while (argument_sdf) {
    std::string argument = argument_sdf->Get<std::string>();
    arguments.push_back(RCL_PARAM_FILE_FLAG);
    arguments.push_back(argument);
    parameter_file_names.push_back(argument);
    argument_sdf = argument_sdf->GetNextElement("parameters");
  }
// ign_ros2_control_plugin.cpp:357
  if (!rclcpp::ok()) {
    rclcpp::init(static_cast<int>(argv.size()), argv.data());
  }
```

When multiple instances of `IgnitionROS2ControlPlugin` are used, the very first instance calls `rclcpp::init`, and since `rclcpp::ok()` is true, `rclcpp::init` is not called from the second instance on. Therefore, the global default context only contains the parameters tag of the very first parameter file. 

I have two possible fixes for this, and would like to get your comment. The first is to use different `rclcpp::Context` for different instances, and then pass the `--params <params-file>` as an argument to `Context::init`. The second is to use node options. 

The first gives more separation between controller manager instances, but requires a corresponding fix in controller manager so that controller node instances inherit controller manager's context. 

The second shares the same global context, and works without modification if the controller parameter yaml ensures to specify the params_file (even if the same file). 

What do you guys think?


