### PR TITLE
Run CI scheduled and add workflow_dispatch

### DIFF
--- a/.github/workflows/ci-rolling.yaml
+++ b/.github/workflows/ci-rolling.yaml
@@ -1,10 +1,14 @@
 name: gz_ros2_control CI - Rolling
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ master ]
   push:
     branches: [ master ]
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 5 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
I had a problem with running it locally and wanted to see if the CI is still happy, but it lacked of a workflow_dispatch option. Maybe a scheduled run is also helpful?