### PR TITLE
Add jazzy workflow and update readme

### DIFF
--- a/.github/workflows/ci-jazzy.yaml
+++ b/.github/workflows/ci-jazzy.yaml
@@ -1,0 +1,69 @@
+name: gz_ros2_control CI - Jazzy
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ jazzy ]
+  push:
+    branches: [ jazzy ]
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 4 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - docker-image: "ubuntu:24.04"
+            ros-distro: "jazzy"
+            ros-repo-packages: "-testing"
+
+    env:
+      DOCKER_IMAGE: ${{ matrix.docker-image }}
+      ROS_DISTRO: ${{ matrix.ros-distro }}
+      ROS_REPO_PACKAGES: ${{ matrix.ros-repo-packages }}
+    container:
+      image: ${{ matrix.docker-image }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup colcon workspace
+      id: configure
+      shell: bash
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt update -qq
+        apt install -qq -y lsb-release wget curl gnupg2 git
+        cd ..
+        mkdir -p /home/ros2_ws/src
+        cp -r gz_ros2_control /home/ros2_ws/src/
+        curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2$ROS_REPO_PACKAGES/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+        apt-get update && apt-get upgrade -q -y
+        apt-get update && apt-get install -qq -y \
+          dirmngr \
+          python3-colcon-ros \
+          python3-colcon-common-extensions \
+          python3-rosdep \
+          build-essential
+
+        cd /home/ros2_ws/src/
+        rosdep init
+        rosdep update
+        rosdep install --from-paths ./ -i -y --rosdistro ${ROS_DISTRO} --ignore-src
+    - name: Build project
+      id: build
+      run: |
+        cd /home/ros2_ws/
+        . /opt/ros/${ROS_DISTRO}/local_setup.sh
+        colcon build --packages-up-to gz_ros2_control_demos gz_ros2_control_tests
+    - name: Run tests
+      id: test
+      run: |
+        cd /home/ros2_ws/
+        . /opt/ros/${ROS_DISTRO}/local_setup.sh
+        colcon test --event-handlers console_direct+ --packages-select gz_ros2_control gz_ros2_control_demos gz_ros2_control_tests
+        colcon test-result

--- a/.github/workflows/ci-jazzy.yaml
+++ b/.github/workflows/ci-jazzy.yaml
@@ -28,7 +28,14 @@ jobs:
     container:
       image: ${{ matrix.docker-image }}
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      if: github.event_name != 'schedule'
+      uses: actions/checkout@v4
+    - name: Checkout code for scheduled workflow
+      if: github.event_name == 'schedule'
+      uses: actions/checkout@v4
+      with:
+        ref: jazzy
     - name: Setup colcon workspace
       id: configure
       shell: bash

--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ Iron | Edifice | [iron](https://github.com/ros-controls/gz_ros2_control/tree/iro
 Iron | Fortress | [iron](https://github.com/ros-controls/gz_ros2_control/tree/iron) | https://packages.ros.org | `ros-iron-gz-ros2-control`
 Iron | Garden | [iron](https://github.com/ros-controls/gz_ros2_control/tree/iron) | only from source |
 Iron | Harmonic | [iron](https://github.com/ros-controls/gz_ros2_control/tree/iron) | only from source |
-Jazzy | Harmonic | [master](https://github.com/ros-controls/gz_ros2_control/tree/master) | https://packages.ros.org | `ros-jazzy-gz-ros2-control`
+Jazzy | Harmonic | [jazzy](https://github.com/ros-controls/gz_ros2_control/tree/jazzy) | https://packages.ros.org | `ros-jazzy-gz-ros2-control`
 Rolling | Harmonic | [master](https://github.com/ros-controls/gz_ros2_control/tree/master) | https://packages.ros.org | `ros-rolling-gz-ros2-control`
 
 ## Build status
 
 ROS 2 Distro | Branch | Build status | Documentation
 :----------: | :----: | :----------: | :-----------:
-**Rolling** | [`master`](https://github.com/ros-controls/gz_ros2_control/tree/master) | [![gazebo_ros2_control CI - Rolling](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-rolling.yaml/badge.svg?branch=master)](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-rolling.yaml) | [Documentation](https://control.ros.org/master/index.html) <br /> [API Reference](https://control.ros.org/master/doc/api/index.html)
+**Rolling** | [`master`](https://github.com/ros-controls/gz_ros2_control/tree/master) | [![gazebo_ros2_control CI - Rolling](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-rolling.yaml/badge.svg?branch=master)](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-rolling.yaml) | [Documentation](https://control.ros.org/rolling/index.html) <br /> [API Reference](https://control.ros.org/rolling/doc/api/index.html)
+**Jazzy** | [`jazzy`](https://github.com/ros-controls/gz_ros2_control/tree/jazzy) | [![gazebo_ros2_control CI - Jazzy](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-jazzy.yaml/badge.svg?branch=master)](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-jazzy.yaml) | [Documentation](https://control.ros.org/jazzy/index.html) <br /> [API Reference](https://control.ros.org/jazzy/doc/api/index.html)
 **Iron** | [`iron`](https://github.com/ros-controls/gz_ros2_control/tree/iron) | [![gazebo_ros2_control CI - Iron](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-iron.yaml/badge.svg?branch=iron)](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-iron.yaml) | [Documentation](https://control.ros.org/iron/index.html) <br /> [API Reference](https://control.ros.org/iron/doc/api/index.html)
 **Humble** | [`humble`](https://github.com/ros-controls/gz_ros2_control/tree/humble) | [![ign_ros2_control CI - Humble](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-humble.yaml/badge.svg?branch=humble)](https://github.com/ros-controls/gz_ros2_control/actions/workflows/ci-humble.yaml) | [Documentation](https://control.ros.org/humble/index.html) <br /> [API Reference](https://control.ros.org/humble/doc/api/index.html)
 ## Documentation


### PR DESCRIPTION
- Update dependency table for jazzy
- Add jazzy workflow (scheduled wf need to be on default branch, am I right?)
- Update docs and CI badges

Rolling job is failing due to https://github.com/ros-controls/gz_ros2_control/issues/395

Tested jazzy job with act (the release with the breaking change was not merged for jazzy yet)

> | Summary: 3 packages finished [18.4s]
> | Summary: 110 tests, 0 errors, 0 failures, 13 skipped
> [gz_ros2_control CI - Jazzy/build]   ✅  Success - Main Run tests
> [gz_ros2_control CI - Jazzy/build] Cleaning up container for job build
> [gz_ros2_control CI - Jazzy/build] 🏁  Job succeeded
