### PR TITLE
Use spawner with `--params-file` argument instead of cli verbs

### DIFF
--- a/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
@@ -5,12 +5,9 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-
-    ackermann_steering_controller:
-      type: 'ackermann_steering_controller/AckermannSteeringController'
-
 ackermann_steering_controller:
   ros__parameters:
+    type: 'ackermann_steering_controller/AckermannSteeringController'
     wheelbase: 1.7
     front_wheel_track: 1.0
     rear_wheel_track: 1.0

--- a/gz_ros2_control_demos/config/cart_controller_effort.yaml
+++ b/gz_ros2_control_demos/config/cart_controller_effort.yaml
@@ -2,13 +2,11 @@ controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
 
-    effort_controller:
-      type: effort_controllers/JointGroupEffortController
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 effort_controller:
   ros__parameters:
+    type: effort_controllers/JointGroupEffortController
     joints:
       - slider_to_cart

--- a/gz_ros2_control_demos/config/cart_controller_position.yaml
+++ b/gz_ros2_control_demos/config/cart_controller_position.yaml
@@ -2,14 +2,12 @@ controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
 
-    joint_trajectory_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 joint_trajectory_controller:
   ros__parameters:
+    type: joint_trajectory_controller/JointTrajectoryController
     joints:
       - slider_to_cart
     command_interfaces:

--- a/gz_ros2_control_demos/config/cart_controller_velocity.yaml
+++ b/gz_ros2_control_demos/config/cart_controller_velocity.yaml
@@ -7,6 +7,7 @@ controller_manager:
 
 velocity_controller:
   ros__parameters:
+    type: velocity_controllers/JointGroupVelocityController
     joints:
       - slider_to_cart
 

--- a/gz_ros2_control_demos/config/cart_controller_velocity.yaml
+++ b/gz_ros2_control_demos/config/cart_controller_velocity.yaml
@@ -2,14 +2,8 @@ controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
 
-    velocity_controller:
-      type: velocity_controllers/JointGroupVelocityController
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
-
-    imu_sensor_broadcaster:
-      type: imu_sensor_broadcaster/IMUSensorBroadcaster
 
 velocity_controller:
   ros__parameters:
@@ -18,5 +12,6 @@ velocity_controller:
 
 imu_sensor_broadcaster:
   ros__parameters:
+    type: imu_sensor_broadcaster/IMUSensorBroadcaster
     sensor_name: cart_imu_sensor
     frame_id: imu

--- a/gz_ros2_control_demos/config/diff_drive_controller_velocity.yaml
+++ b/gz_ros2_control_demos/config/diff_drive_controller_velocity.yaml
@@ -5,11 +5,9 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    diff_drive_base_controller:
-      type: diff_drive_controller/DiffDriveController
-
 diff_drive_base_controller:
   ros__parameters:
+    type: diff_drive_controller/DiffDriveController
     left_wheel_names: ["left_wheel_joint"]
     right_wheel_names: ["right_wheel_joint"]
 

--- a/gz_ros2_control_demos/config/gripper_controller_effort.yaml
+++ b/gz_ros2_control_demos/config/gripper_controller_effort.yaml
@@ -2,14 +2,12 @@ controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
 
-    gripper_controller:
-      type: forward_command_controller/ForwardCommandController
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 gripper_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - right_finger_joint
     interface_name: effort

--- a/gz_ros2_control_demos/config/gripper_controller_position.yaml
+++ b/gz_ros2_control_demos/config/gripper_controller_position.yaml
@@ -2,14 +2,12 @@ controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
 
-    gripper_controller:
-      type: forward_command_controller/ForwardCommandController
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 gripper_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - right_finger_joint
     interface_name: position

--- a/gz_ros2_control_demos/config/tricycle_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/tricycle_drive_controller.yaml
@@ -2,18 +2,15 @@ controller_manager:
   ros__parameters:
     update_rate: 50 # Hz
 
-    tricycle_controller:
-      type: tricycle_controller/TricycleController
-
-    joint_state_broadcaster:
-      type: joint_state_broadcaster/JointStateBroadcaster
-
 joint_state_broadcaster:
   ros__parameters:
+    type: joint_state_broadcaster/JointStateBroadcaster
     extra_joints: ["right_wheel_joint", "left_wheel_joint"]
 
 tricycle_controller:
   ros__parameters:
+    type: tricycle_controller/TricycleController
+
     # Model
     traction_joint_name: traction_joint # Name of traction joint in URDF
     steering_joint_name: steering_joint # Name of steering joint in URDF

--- a/gz_ros2_control_demos/examples/example_ackermann_drive.cpp
+++ b/gz_ros2_control_demos/examples/example_ackermann_drive.cpp
@@ -17,7 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
 using namespace std::chrono_literals;
 
@@ -28,22 +28,26 @@ int main(int argc, char * argv[])
   std::shared_ptr<rclcpp::Node> node =
     std::make_shared<rclcpp::Node>("ackermann_drive_test_node");
 
-  auto publisher = node->create_publisher<geometry_msgs::msg::Twist>(
-    "/ackermann_steering_controller/reference_unstamped", 10);
+  auto publisher = node->create_publisher<geometry_msgs::msg::TwistStamped>(
+    "/ackermann_steering_controller/reference", 10);
 
   RCLCPP_INFO(node->get_logger(), "node created");
 
-  geometry_msgs::msg::Twist command;
+  geometry_msgs::msg::Twist tw;
 
-  command.linear.x = 0.5;
-  command.linear.y = 0.0;
-  command.linear.z = 0.0;
+  tw.linear.x = 0.5;
+  tw.linear.y = 0.0;
+  tw.linear.z = 0.0;
 
-  command.angular.x = 0.0;
-  command.angular.y = 0.0;
-  command.angular.z = 0.3;
+  tw.angular.x = 0.0;
+  tw.angular.y = 0.0;
+  tw.angular.z = 0.3;
+
+  geometry_msgs::msg::TwistStamped command;
+  command.twist = tw;
 
   while (1) {
+    command.header.stamp = node->now();
     publisher->publish(command);
     std::this_thread::sleep_for(50ms);
     rclcpp::spin_some(node);

--- a/gz_ros2_control_demos/examples/example_diff_drive.cpp
+++ b/gz_ros2_control_demos/examples/example_diff_drive.cpp
@@ -34,8 +34,6 @@ int main(int argc, char * argv[])
 
   geometry_msgs::msg::TwistStamped command;
 
-  command.header.stamp = node->now();
-
   command.twist.linear.x = 0.1;
   command.twist.linear.y = 0.0;
   command.twist.linear.z = 0.0;
@@ -45,6 +43,7 @@ int main(int argc, char * argv[])
   command.twist.angular.z = 0.1;
 
   while (1) {
+    command.header.stamp = node->now();
     publisher->publish(command);
     std::this_thread::sleep_for(50ms);
     rclcpp::spin_some(node);

--- a/gz_ros2_control_demos/examples/example_gripper.cpp
+++ b/gz_ros2_control_demos/examples/example_gripper.cpp
@@ -23,13 +23,11 @@
 
 #include "std_msgs/msg/float64_multi_array.hpp"
 
-std::shared_ptr<rclcpp::Node> node;
-
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  node = std::make_shared<rclcpp::Node>("gripper_test_node");
+  std::shared_ptr<rclcpp::Node> node = std::make_shared<rclcpp::Node>("gripper_test_node");
 
   auto publisher = node->create_publisher<std_msgs::msg::Float64MultiArray>(
     "/gripper_controller/commands", 10);

--- a/gz_ros2_control_demos/examples/example_position.cpp
+++ b/gz_ros2_control_demos/examples/example_position.cpp
@@ -154,7 +154,7 @@ int main(int argc, char * argv[])
     node.reset();
     return 1;
   }
-  RCLCPP_ERROR(node->get_logger(), "send goal call ok :)");
+  RCLCPP_INFO(node->get_logger(), "send goal call ok :)");
 
   rclcpp_action::ClientGoalHandle<control_msgs::action::FollowJointTrajectory>::SharedPtr
     goal_handle = goal_handle_future.get();
@@ -164,7 +164,7 @@ int main(int argc, char * argv[])
     node.reset();
     return 1;
   }
-  RCLCPP_ERROR(node->get_logger(), "Goal was accepted by server");
+  RCLCPP_INFO(node->get_logger(), "Goal was accepted by server");
 
   // Wait for the server to be done with the goal
   auto result_future = action_client->async_get_result(goal_handle);

--- a/gz_ros2_control_demos/examples/example_tricycle_drive.cpp
+++ b/gz_ros2_control_demos/examples/example_tricycle_drive.cpp
@@ -34,8 +34,6 @@ int main(int argc, char * argv[])
 
   geometry_msgs::msg::TwistStamped command;
 
-  command.header.stamp = node->now();
-
   command.twist.linear.x = 0.2;
   command.twist.linear.y = 0.0;
   command.twist.linear.z = 0.0;
@@ -45,6 +43,7 @@ int main(int argc, char * argv[])
   command.twist.angular.z = 0.1;
 
   while (1) {
+    command.header.stamp = node->now();
     publisher->publish(command);
     std::this_thread::sleep_for(50ms);
     rclcpp::spin_some(node);

--- a/gz_ros2_control_demos/launch/cart_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/cart_example_effort.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -39,6 +39,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'cart_controller_effort.yaml',
+        ]
+    )
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -55,16 +62,19 @@ def generate_launch_description():
                    '-name', 'cart', '-allow_renaming', 'true'],
     )
 
-    load_joint_state_broadcaster = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster'],
     )
-
-    load_joint_effort_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller',
-             '--set-state', 'active', 'effort_controller'],
-        output='screen'
+    effort_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'effort_controller',
+            '--param-file',
+            robot_controllers,
+            ],
     )
 
     return LaunchDescription([
@@ -78,13 +88,13 @@ def generate_launch_description():
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,
-                on_exit=[load_joint_state_broadcaster],
+                on_exit=[joint_state_broadcaster_spawner],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_broadcaster,
-                on_exit=[load_joint_effort_controller],
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[effort_controller_spawner],
             )
         ),
         node_robot_state_publisher,

--- a/gz_ros2_control_demos/launch/cart_example_position.launch.py
+++ b/gz_ros2_control_demos/launch/cart_example_position.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -39,6 +39,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'cart_controller_position.yaml',
+        ]
+    )
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -55,16 +62,19 @@ def generate_launch_description():
                    '-name', 'cart', '-allow_renaming', 'true'],
     )
 
-    load_joint_state_broadcaster = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster'],
     )
-
-    load_joint_trajectory_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_trajectory_controller'],
-        output='screen'
+    joint_trajectory_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'joint_trajectory_controller',
+            '--param-file',
+            robot_controllers,
+            ],
     )
 
     return LaunchDescription([
@@ -78,13 +88,13 @@ def generate_launch_description():
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,
-                on_exit=[load_joint_state_broadcaster],
+                on_exit=[joint_state_broadcaster_spawner],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_broadcaster,
-                on_exit=[load_joint_trajectory_controller],
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[joint_trajectory_controller_spawner],
             )
         ),
         node_robot_state_publisher,

--- a/gz_ros2_control_demos/launch/cart_example_velocity.launch.py
+++ b/gz_ros2_control_demos/launch/cart_example_velocity.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -39,6 +39,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'cart_controller_velocity.yaml',
+        ]
+    )
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -55,16 +62,28 @@ def generate_launch_description():
                    '-name', 'cart', '-allow_renaming', 'true'],
     )
 
-    load_joint_state_broadcaster = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster'],
     )
-
-    load_joint_velocity_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller',
-             '--set-state', 'active', 'velocity_controller'],
-        output='screen'
+    velocity_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'velocity_controller',
+            '--param-file',
+            robot_controllers,
+            ],
+    )
+    imu_sensor_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'imu_sensor_broadcaster',
+            '--param-file',
+            robot_controllers,
+            ],
     )
 
     return LaunchDescription([
@@ -78,13 +97,14 @@ def generate_launch_description():
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,
-                on_exit=[load_joint_state_broadcaster],
+                on_exit=[joint_state_broadcaster_spawner],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_broadcaster,
-                on_exit=[load_joint_velocity_controller],
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[velocity_controller_spawner,
+                         imu_sensor_broadcaster_spawner],
             )
         ),
         node_robot_state_publisher,

--- a/gz_ros2_control_demos/launch/diff_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/diff_drive_example.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -39,6 +39,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'diff_drive_controller_velocity.yaml',
+        ]
+    )
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -55,16 +62,19 @@ def generate_launch_description():
                    'diff_drive', '-allow_renaming', 'true'],
     )
 
-    load_joint_state_broadcaster = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster'],
     )
-
-    load_diff_drive_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'diff_drive_base_controller'],
-        output='screen'
+    diff_drive_base_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'diff_drive_base_controller',
+            '--param-file',
+            robot_controllers,
+            ],
     )
 
     return LaunchDescription([
@@ -78,13 +88,13 @@ def generate_launch_description():
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,
-                on_exit=[load_joint_state_broadcaster],
+                on_exit=[joint_state_broadcaster_spawner],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_broadcaster,
-                on_exit=[load_diff_drive_controller],
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[diff_drive_base_controller_spawner],
             )
         ),
         node_robot_state_publisher,

--- a/gz_ros2_control_demos/launch/gripper_mimic_joint_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/gripper_mimic_joint_example_effort.launch.py
@@ -16,7 +16,7 @@
 #
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -42,6 +42,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'gripper_controller_effort.yaml',
+        ]
+    )
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -58,16 +65,19 @@ def generate_launch_description():
                    'gripper', '-allow_renaming', 'true'],
     )
 
-    load_joint_state_broadcaster = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster'],
     )
-
-    load_gripper_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'gripper_controller'],
-        output='screen'
+    gripper_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'gripper_controller',
+            '--param-file',
+            robot_controllers,
+            ],
     )
 
     return LaunchDescription([
@@ -81,13 +91,13 @@ def generate_launch_description():
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,
-                on_exit=[load_joint_state_broadcaster],
+                on_exit=[joint_state_broadcaster_spawner],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_broadcaster,
-                on_exit=[load_gripper_controller],
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[gripper_controller_spawner],
             )
         ),
         node_robot_state_publisher,

--- a/gz_ros2_control_demos/launch/gripper_mimic_joint_example_effort.launch.xml
+++ b/gz_ros2_control_demos/launch/gripper_mimic_joint_example_effort.launch.xml
@@ -26,6 +26,7 @@ Author: Dr. Denis
 
   <!-- Load description and start controllers -->
   <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share gz_ros2_control_demos)/urdf/test_gripper_mimic_joint_effort.xacro.urdf')" />
+  <let name="robot_controllers" value="$(find-pkg-share gz_ros2_control_demos)/config/gripper_controller_effort.yaml"/>
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
     <param name="robot_description" value="$(var robot_description_content)" />
@@ -50,8 +51,8 @@ Author: Dr. Denis
   <node pkg="controller_manager" exec="spawner" args="joint_state_broadcaster">
     <param name="use_sim_time" value="true" />
   </node>
-  <!--Mobile Base Controller-->
-  <node pkg="controller_manager" exec="spawner" args="gripper_controller">
+  <!--Gripper Controller-->
+  <node pkg="controller_manager" exec="spawner" args="gripper_controller --param-file $(var robot_controllers)">
     <param name="use_sim_time" value="true" />
   </node>
 

--- a/gz_ros2_control_demos/launch/gripper_mimic_joint_example_position.launch.xml
+++ b/gz_ros2_control_demos/launch/gripper_mimic_joint_example_position.launch.xml
@@ -26,6 +26,7 @@ Author: Dr. Denis
 
   <!-- Load description and start controllers -->
   <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share gz_ros2_control_demos)/urdf/test_gripper_mimic_joint_position.xacro.urdf')" />
+  <let name="robot_controllers" value="$(find-pkg-share gz_ros2_control_demos)/config/gripper_controller_position.yaml"/>
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
     <param name="robot_description" value="$(var robot_description_content)" />
@@ -50,8 +51,8 @@ Author: Dr. Denis
   <node pkg="controller_manager" exec="spawner" args="joint_state_broadcaster">
     <param name="use_sim_time" value="true" />
   </node>
-  <!--Mobile Base Controller-->
-  <node pkg="controller_manager" exec="spawner" args="gripper_controller">
+  <!--Gripper Controller-->
+  <node pkg="controller_manager" exec="spawner" args="gripper_controller --param-file $(var robot_controllers)">
     <param name="use_sim_time" value="true" />
   </node>
 

--- a/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -39,6 +39,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'cart_controller_effort.yaml',
+        ]
+    )
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -55,16 +62,19 @@ def generate_launch_description():
                    '-name', 'cart', '-allow_renaming', 'true'],
     )
 
-    load_joint_state_broadcaster = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster'],
     )
-
-    load_joint_effort_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller',
-             '--set-state', 'active', 'effort_controller'],
-        output='screen'
+    effort_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'effort_controller',
+            '--param-file',
+            robot_controllers,
+            ],
     )
 
     return LaunchDescription([
@@ -78,13 +88,13 @@ def generate_launch_description():
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,
-                on_exit=[load_joint_state_broadcaster],
+                on_exit=[joint_state_broadcaster_spawner],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_broadcaster,
-                on_exit=[load_joint_effort_controller],
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[effort_controller_spawner],
             )
         ),
         node_robot_state_publisher,

--- a/gz_ros2_control_demos/launch/pendulum_example_position.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_position.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -39,6 +39,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'cart_controller_position.yaml',
+        ]
+    )
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -55,16 +62,19 @@ def generate_launch_description():
                    '-name', 'cart', '-allow_renaming', 'true'],
     )
 
-    load_joint_state_broadcaster = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster'],
     )
-
-    load_joint_trajectory_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_trajectory_controller'],
-        output='screen'
+    joint_trajectory_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'joint_trajectory_controller',
+            '--param-file',
+            robot_controllers,
+            ],
     )
 
     return LaunchDescription([
@@ -78,13 +88,13 @@ def generate_launch_description():
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,
-                on_exit=[load_joint_state_broadcaster],
+                on_exit=[joint_state_broadcaster_spawner],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_broadcaster,
-                on_exit=[load_joint_trajectory_controller],
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[joint_trajectory_controller_spawner],
             )
         ),
         node_robot_state_publisher,

--- a/gz_ros2_control_demos/launch/tricycle_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/tricycle_drive_example.launch.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -39,6 +39,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'tricycle_drive_controller.yaml',
+        ]
+    )
 
     node_robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -55,16 +62,23 @@ def generate_launch_description():
                    'tricyle', '-allow_renaming', 'true'],
     )
 
-    load_joint_state_broadcaster = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'joint_state_broadcaster'],
-        output='screen'
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'joint_state_broadcaster',
+            '--param-file',
+            robot_controllers,
+            ],
     )
-
-    load_tricycle_controller = ExecuteProcess(
-        cmd=['ros2', 'control', 'load_controller', '--set-state', 'active',
-             'tricycle_controller'],
-        output='screen'
+    tricycle_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'tricycle_controller',
+            '--param-file',
+            robot_controllers,
+            ],
     )
 
     # Bridge
@@ -87,13 +101,13 @@ def generate_launch_description():
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,
-                on_exit=[load_joint_state_broadcaster],
+                on_exit=[joint_state_broadcaster_spawner],
             )
         ),
         RegisterEventHandler(
             event_handler=OnProcessExit(
-                target_action=load_joint_state_broadcaster,
-                on_exit=[load_tricycle_controller],
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[tricycle_controller_spawner],
             )
         ),
         node_robot_state_publisher,

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -23,28 +23,30 @@
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>ament_index_python</exec_depend>
-  <exec_depend>control_msgs</exec_depend>
-  <exec_depend>effort_controllers</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>gz_ros2_control</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
+  <!-- ros2_control -->
+  <exec_depend>ackermann_steering_controller</exec_depend>
+  <exec_depend>control_msgs</exec_depend>
+  <exec_depend>diff_drive_controller</exec_depend>
+  <exec_depend>effort_controllers</exec_depend>
+  <exec_depend>gz_ros2_control</exec_depend>
+  <exec_depend>hardware_interface</exec_depend>
   <exec_depend>imu_sensor_broadcaster</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
-  <exec_depend>launch</exec_depend>
-  <exec_depend>launch_ros</exec_depend>
-  <exec_depend>ros2launch</exec_depend>
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>velocity_controllers</exec_depend>
-  <exec_depend>diff_drive_controller</exec_depend>
   <exec_depend>tricycle_controller</exec_depend>
-  <exec_depend>ackermann_steering_controller</exec_depend>
-  <exec_depend>xacro</exec_depend>
+  <exec_depend>velocity_controllers</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/gz_ros2_control_tests/config/cart_controller_position.yaml
+++ b/gz_ros2_control_tests/config/cart_controller_position.yaml
@@ -2,14 +2,12 @@ controller_manager:
   ros__parameters:
     update_rate: 1000  # Hz
 
-    joint_trajectory_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 joint_trajectory_controller:
   ros__parameters:
+    type: joint_trajectory_controller/JointTrajectoryController
     joints:
       - slider_to_cart
     command_interfaces:


### PR DESCRIPTION
This repo is now in line with the ros2_control_demo repo, especially https://github.com/ros-controls/ros2_control_demos/pull/502

I tested all examples and fixed some other stuff (wrong topic for ackermann steering controller etc). I'll create a manual backport for iron.

Fixes #395 