### PR TITLE
Add remap option to controller manager

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -437,6 +437,10 @@ void GazeboSimROS2ControlPlugin::Configure(
   // Create the controller manager
   RCLCPP_INFO(this->dataPtr->node_->get_logger(), "Loading controller_manager");
   rclcpp::NodeOptions options = controller_manager::get_cm_node_options();
+  arguments.push_back("-r");
+  arguments.push_back("__node:=" + controllerManagerNodeName);
+  arguments.push_back("-r");
+  arguments.push_back("__ns:=" + ns);
   options.arguments(arguments);
   this->dataPtr->controller_manager_.reset(
     new controller_manager::ControllerManager(


### PR DESCRIPTION
I made it possible to correctly set the node name of the `controller_manager` when launching `gz_ros2_control` as a composable node.

- fix #441 