### PR TITLE
Add missing bridges for simulation time

### DIFF
--- a/gz_ros2_control_demos/launch/cart_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/cart_example_effort.launch.py
@@ -77,6 +77,14 @@ def generate_launch_description():
             ],
     )
 
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -97,6 +105,7 @@ def generate_launch_description():
                 on_exit=[effort_controller_spawner],
             )
         ),
+        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/gz_ros2_control_demos/launch/cart_example_position.launch.py
+++ b/gz_ros2_control_demos/launch/cart_example_position.launch.py
@@ -65,7 +65,8 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
         executable='spawner',
-        arguments=['joint_state_broadcaster'],
+        arguments=['joint_state_broadcaster',
+                   ],
     )
     joint_trajectory_controller_spawner = Node(
         package='controller_manager',
@@ -75,6 +76,14 @@ def generate_launch_description():
             '--param-file',
             robot_controllers,
             ],
+    )
+
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
     )
 
     return LaunchDescription([
@@ -97,6 +106,7 @@ def generate_launch_description():
                 on_exit=[joint_trajectory_controller_spawner],
             )
         ),
+        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/gz_ros2_control_demos/launch/cart_example_velocity.launch.py
+++ b/gz_ros2_control_demos/launch/cart_example_velocity.launch.py
@@ -86,6 +86,14 @@ def generate_launch_description():
             ],
     )
 
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -107,6 +115,7 @@ def generate_launch_description():
                          imu_sensor_broadcaster_spawner],
             )
         ),
+        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/gz_ros2_control_demos/launch/diff_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/diff_drive_example.launch.py
@@ -77,6 +77,14 @@ def generate_launch_description():
             ],
     )
 
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -97,6 +105,7 @@ def generate_launch_description():
                 on_exit=[diff_drive_base_controller_spawner],
             )
         ),
+        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/gz_ros2_control_demos/launch/gripper_mimic_joint_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/gripper_mimic_joint_example_effort.launch.py
@@ -80,6 +80,14 @@ def generate_launch_description():
             ],
     )
 
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -100,6 +108,7 @@ def generate_launch_description():
                 on_exit=[gripper_controller_spawner],
             )
         ),
+        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/gz_ros2_control_demos/launch/gripper_mimic_joint_example_position.launch.py
+++ b/gz_ros2_control_demos/launch/gripper_mimic_joint_example_position.launch.py
@@ -80,6 +80,14 @@ def generate_launch_description():
             ],
     )
 
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -100,6 +108,7 @@ def generate_launch_description():
                 on_exit=[gripper_controller_spawner],
             )
         ),
+        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
@@ -77,6 +77,14 @@ def generate_launch_description():
             ],
     )
 
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -97,6 +105,7 @@ def generate_launch_description():
                 on_exit=[effort_controller_spawner],
             )
         ),
+        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/gz_ros2_control_demos/launch/pendulum_example_position.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_position.launch.py
@@ -77,6 +77,14 @@ def generate_launch_description():
             ],
     )
 
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -97,6 +105,7 @@ def generate_launch_description():
                 on_exit=[joint_trajectory_controller_spawner],
             )
         ),
+        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/gz_ros2_control_tests/tests/position_test.py
+++ b/gz_ros2_control_tests/tests/position_test.py
@@ -101,8 +101,17 @@ def generate_test_description():
             ],
     )
 
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
     ld = launch.LaunchDescription([
         included_launch,
+        bridge,
         gz_spawn_entity,
         node_robot_state_publisher,
         RegisterEventHandler(


### PR DESCRIPTION
We need a parameter bridge for receiving the simulation time in the ROS world.

Some of them got (accidentally?) removed with #266, others never had the bridge.

Fixes #439