### PR TITLE
Fix ackermann demo

### DIFF
--- a/ign_ros2_control_demos/config/ackermann_drive_controller.yaml
+++ b/ign_ros2_control_demos/config/ackermann_drive_controller.yaml
@@ -20,6 +20,7 @@ ackermann_steering_controller:
     reference_timeout: 2.0
     rear_wheels_names: ['rear_left_wheel_joint', 'rear_right_wheel_joint']
     front_wheels_names: ['left_wheel_steering_joint', 'right_wheel_steering_joint']
+    use_stamped_vel: true
     open_loop: false
     velocity_rolling_window_size: 10
     base_frame_id: base_link

--- a/ign_ros2_control_demos/examples/example_ackermann_drive.cpp
+++ b/ign_ros2_control_demos/examples/example_ackermann_drive.cpp
@@ -28,6 +28,8 @@ int main(int argc, char * argv[])
   std::shared_ptr<rclcpp::Node> node =
     std::make_shared<rclcpp::Node>("ackermann_drive_test_node");
 
+  node->set_parameter(rclcpp::Parameter("use_sim_time", true));
+
   auto publisher = node->create_publisher<geometry_msgs::msg::TwistStamped>(
     "/ackermann_steering_controller/reference", 10);
 
@@ -47,10 +49,12 @@ int main(int argc, char * argv[])
   command.twist = tw;
 
   while (1) {
-    command.header.stamp = node->now();
-    publisher->publish(command);
-    std::this_thread::sleep_for(50ms);
     rclcpp::spin_some(node);
+    if (node->get_clock()->started()) {
+      command.header.stamp = node->now();
+      publisher->publish(command);
+    }
+    std::this_thread::sleep_for(50ms);
   }
   rclcpp::shutdown();
 

--- a/ign_ros2_control_demos/examples/example_ackermann_drive.cpp
+++ b/ign_ros2_control_demos/examples/example_ackermann_drive.cpp
@@ -17,7 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
 
 using namespace std::chrono_literals;
 
@@ -28,22 +28,26 @@ int main(int argc, char * argv[])
   std::shared_ptr<rclcpp::Node> node =
     std::make_shared<rclcpp::Node>("ackermann_drive_test_node");
 
-  auto publisher = node->create_publisher<geometry_msgs::msg::Twist>(
-    "/ackermann_steering_controller/reference_unstamped", 10);
+  auto publisher = node->create_publisher<geometry_msgs::msg::TwistStamped>(
+    "/ackermann_steering_controller/reference", 10);
 
   RCLCPP_INFO(node->get_logger(), "node created");
 
-  geometry_msgs::msg::Twist command;
+  geometry_msgs::msg::Twist tw;
 
-  command.linear.x = 0.5;
-  command.linear.y = 0.0;
-  command.linear.z = 0.0;
+  tw.linear.x = 0.5;
+  tw.linear.y = 0.0;
+  tw.linear.z = 0.0;
 
-  command.angular.x = 0.0;
-  command.angular.y = 0.0;
-  command.angular.z = 0.3;
+  tw.angular.x = 0.0;
+  tw.angular.y = 0.0;
+  tw.angular.z = 0.3;
+
+  geometry_msgs::msg::TwistStamped command;
+  command.twist = tw;
 
   while (1) {
+    command.header.stamp = node->now();
     publisher->publish(command);
     std::this_thread::sleep_for(50ms);
     rclcpp::spin_some(node);

--- a/ign_ros2_control_demos/launch/ackermann_drive_example.launch.py
+++ b/ign_ros2_control_demos/launch/ackermann_drive_example.launch.py
@@ -96,7 +96,6 @@ def generate_launch_description():
                 on_exit=[load_ackermann_controller],
             )
         ),
-        bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         # Launch Arguments

--- a/ign_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/ign_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -34,8 +34,8 @@
 
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0" />
-      <mass value="1" />
-      <inertia ixx="0.126164" ixy="0.0" ixz="0.0" iyy="0.416519" iyz="0.0" izz="0.481014" />
+      <mass value="100" />
+      <inertia ixx="10.4" ixy="0.0" ixz="0.0" iyy="35.4" iyz="0.0" izz="41.66" />
     </inertial>
   </link>
 
@@ -60,8 +60,8 @@
     </visual>
 
     <inertial>
-      <mass value="2" />
-      <inertia ixx="0.145833" ixy="0.0" ixz="0.0" iyy="0.145833" iyz="0.0" izz="0.125" />
+      <mass value="11.3" />
+      <inertia ixx="0.26" ixy="0.0" ixz="0.0" iyy="0.26" iyz="0.0" izz="0.51" />
     </inertial>
   </link>
 
@@ -87,8 +87,8 @@
       <material name="Black" />
     </visual>
     <inertial>
-      <mass value="2" />
-      <inertia ixx="0.145833" ixy="0.0" ixz="0.0" iyy="0.145833" iyz="0.0" izz="0.125" />
+      <mass value="11.3" />
+      <inertia ixx="0.26" ixy="0.0" ixz="0.0" iyy="0.26" iyz="0.0" izz="0.51" />
     </inertial>
   </link>
 
@@ -108,12 +108,13 @@
     </inertial>
   </link>
 
-  <joint name="left_wheel_steering_joint" type="continuous">
-    <origin xyz="0.9 0.5 -0.2" rpy="-1.57 0 0" />
+  <joint name="left_wheel_steering_joint" type="revolute">
+    <origin xyz="0.9 -0.5 -0.2" rpy="1.57 0 0" />
     <parent link="chassis" />
     <child link="left_wheel_steering" />
     <axis xyz="0 1 0" />
     <dynamics damping="0.2" />
+    <limit effort="1000.0" lower="-1.57" upper="1.57" velocity="30"/>
   </joint>
 
   <!-- right steer Link -->
@@ -124,12 +125,13 @@
     </inertial>
   </link>
 
-  <joint name="right_wheel_steering_joint" type="continuous">
-    <origin xyz="0.9 -0.5 -0.2" rpy="-1.57 0 0" />
+  <joint name="right_wheel_steering_joint" type="revolute">
+    <origin xyz="0.9 0.5 -0.2" rpy="1.57 0 0" />
     <parent link="chassis" />
     <child link="right_wheel_steering" />
     <axis xyz="0 1 0" />
     <dynamics damping="0.2" />
+    <limit effort="1000.0" lower="-1.57" upper="1.57" velocity="30"/>
   </joint>
 
   <!-- front left wheel Link -->
@@ -146,8 +148,8 @@
       <material name="Black" />
     </visual>
     <inertial>
-      <mass value="2" />
-      <inertia ixx="0.145833" ixy="0.0" ixz="0.0" iyy="0.145833" iyz="0.0" izz="0.125" />
+      <mass value="11.3" />
+      <inertia ixx="0.26" ixy="0.0" ixz="0.0" iyy="0.26" iyz="0.0" izz="0.51" />
     </inertial>
   </link>
 
@@ -173,8 +175,8 @@
       <material name="Black" />
     </visual>
     <inertial>
-      <mass value="2" />
-      <inertia ixx="0.145833" ixy="0.0" ixz="0.0" iyy="0.145833" iyz="0.0" izz="0.125" />
+      <mass value="11.3" />
+      <inertia ixx="0.26" ixy="0.0" ixz="0.0" iyy="0.26" iyz="0.0" izz="0.51" />
     </inertial>
   </link>
 


### PR DESCRIPTION
To fix #438 I changed the definition of the steering joints (and also used meaningful inertial parameters).

While reproducing #438 I found another issue with the example, the launch file crashed and didn't even start.

I also changed the deprecated `Twist` command to `TwistStamped` to avoid 
```
[ruby $(which ign) gazebo-2] [WARN] [1735417503.762406833] [ackermann_steering_controller]: Use of Twist message without stamped is deprecated and it will be removed in ROS 2 J-Turtle version. Use '~/reference' topic with 'geometry_msgs::msg::TwistStamped' message type in the future.
```