### PR TITLE
Set robot description parameter for controllers

### DIFF
--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -338,18 +338,14 @@ void IgnitionROS2ControlPlugin::Configure(
     }
   }
 
-  std::vector<const char *> argv;
-  for (const auto & arg : arguments) {
-    argv.push_back(reinterpret_cast<const char *>(arg.data()));
-  }
-
   // Create a default context, if not already
   if (!rclcpp::ok()) {
+    RCLCPP_DEBUG_STREAM(logger, "Create default context");
+    std::vector<const char *> argv;
     rclcpp::init(static_cast<int>(argv.size()), argv.data());
   }
 
   std::string node_name = "gz_ros2_control";
-
   this->dataPtr->node_ = rclcpp::Node::make_shared(node_name, ns);
   this->dataPtr->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
   this->dataPtr->executor_->add_node(this->dataPtr->node_);
@@ -358,6 +354,44 @@ void IgnitionROS2ControlPlugin::Configure(
       this->dataPtr->executor_->spin();
     };
   this->dataPtr->thread_executor_spin_ = std::thread(spin);
+
+  RCLCPP_DEBUG_STREAM(logger, "Create node " << node_name);
+
+  // Read urdf from ros parameter server
+  std::string urdf_string;
+  urdf_string = this->dataPtr->getURDF();
+  if (urdf_string.empty()) {
+    RCLCPP_ERROR_STREAM(this->dataPtr->node_->get_logger(), "An empty URDF was passed. Exiting.");
+    return;
+  }
+
+  // set the robot description as argument
+  // to propagate it among controller manager and controllers
+  std::string rb_arg = std::string("robot_description:=") + urdf_string;
+  arguments.push_back(RCL_PARAM_FLAG);
+  arguments.push_back(rb_arg);
+
+  std::vector<const char *> argv;
+  for (const auto & arg : arguments) {
+    argv.push_back(reinterpret_cast<const char *>(arg.data()));
+  }
+
+  // set the arguments into rcl context
+  rcl_arguments_t rcl_args = rcl_get_zero_initialized_arguments();
+  rcl_ret_t rcl_ret = rcl_parse_arguments(
+    static_cast<int>(argv.size()),
+    argv.data(), rcl_get_default_allocator(), &rcl_args);
+  auto rcl_context = this->dataPtr->node_->get_node_base_interface()->get_context()->get_rcl_context();
+  rcl_context->global_arguments = rcl_args;
+  if (rcl_ret != RCL_RET_OK) {
+    RCLCPP_ERROR_STREAM(this->dataPtr->node_->get_logger(), "Argument parser error:" << rcl_get_error_string().str);
+    rcl_reset_error();
+    return;
+  }
+  if (rcl_arguments_get_param_files_count(&rcl_args) < 1) {
+    RCLCPP_ERROR(this->dataPtr->node_->get_logger(), "Failed to parse input yaml file(s)");
+    return;
+  }
 
   RCLCPP_DEBUG_STREAM(
     this->dataPtr->node_->get_logger(), "[Ignition ROS 2 Control] Setting up controller for [" <<
@@ -378,10 +412,8 @@ void IgnitionROS2ControlPlugin::Configure(
   // Read urdf from ros parameter server then
   // setup actuators and mechanism control node.
   // This call will block if ROS is not properly initialized.
-  std::string urdf_string;
   std::vector<hardware_interface::HardwareInfo> control_hardware_info;
   try {
-    urdf_string = this->dataPtr->getURDF();
     control_hardware_info = hardware_interface::parse_control_resources_from_urdf(urdf_string);
   } catch (const std::runtime_error & ex) {
     RCLCPP_ERROR_STREAM(

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -381,10 +381,12 @@ void IgnitionROS2ControlPlugin::Configure(
   rcl_ret_t rcl_ret = rcl_parse_arguments(
     static_cast<int>(argv.size()),
     argv.data(), rcl_get_default_allocator(), &rcl_args);
-  auto rcl_context = this->dataPtr->node_->get_node_base_interface()->get_context()->get_rcl_context();
+  auto rcl_context = 
+    this->dataPtr->node_->get_node_base_interface()->get_context()->get_rcl_context();
   rcl_context->global_arguments = rcl_args;
   if (rcl_ret != RCL_RET_OK) {
-    RCLCPP_ERROR_STREAM(this->dataPtr->node_->get_logger(), "Argument parser error:" << rcl_get_error_string().str);
+    RCLCPP_ERROR_STREAM(
+      this->dataPtr->node_->get_logger(), "Argument parser error:" << rcl_get_error_string().str);
     rcl_reset_error();
     return;
   }

--- a/ign_ros2_control/src/ign_ros2_control_plugin.cpp
+++ b/ign_ros2_control/src/ign_ros2_control_plugin.cpp
@@ -381,7 +381,7 @@ void IgnitionROS2ControlPlugin::Configure(
   rcl_ret_t rcl_ret = rcl_parse_arguments(
     static_cast<int>(argv.size()),
     argv.data(), rcl_get_default_allocator(), &rcl_args);
-  auto rcl_context = 
+  auto rcl_context =
     this->dataPtr->node_->get_node_base_interface()->get_context()->get_rcl_context();
   rcl_context->global_arguments = rcl_args;
   if (rcl_ret != RCL_RET_OK) {


### PR DESCRIPTION
Hello,

this patch sets the robot description parameter, so it can be accessible from controllers. 

Similar to the patch done for gazebo_ros2_control https://github.com/ros-controls/gazebo_ros2_control/pull/277

Without the patch:
```
/controller_manager:
  joint_state_broadcaster.type
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  qos_overrides./parameter_events.publisher.depth
  qos_overrides./parameter_events.publisher.durability
  qos_overrides./parameter_events.publisher.history
  qos_overrides./parameter_events.publisher.reliability
  update_rate
  use_sim_time
/joint_state_broadcaster:
  extra_joints
  interfaces
  joints
  map_interface_to_joint_state.effort
  map_interface_to_joint_state.position
  map_interface_to_joint_state.velocity
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  update_rate
  use_local_topics
  use_sim_time
```
With the patch:
```
/controller_manager:
  joint_state_broadcaster.type
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  qos_overrides./parameter_events.publisher.depth
  qos_overrides./parameter_events.publisher.durability
  qos_overrides./parameter_events.publisher.history
  qos_overrides./parameter_events.publisher.reliability
  robot_description
  update_rate
  use_sim_time
/joint_state_broadcaster:
  extra_joints
  interfaces
  joints
  map_interface_to_joint_state.effort
  map_interface_to_joint_state.position
  map_interface_to_joint_state.velocity
  qos_overrides./clock.subscription.depth
  qos_overrides./clock.subscription.durability
  qos_overrides./clock.subscription.history
  qos_overrides./clock.subscription.reliability
  robot_description
  update_rate
  use_local_topics
  use_sim_time
```

It will fix the open issue: https://github.com/ros-controls/gz_ros2_control/issues/168

@ahcorde
@christophfroehlich