### PR TITLE
Fix example_diff_drive

### DIFF
--- a/ign_ros2_control_demos/examples/example_diff_drive.cpp
+++ b/ign_ros2_control_demos/examples/example_diff_drive.cpp
@@ -38,9 +38,9 @@ int main(int argc, char * argv[])
   command.linear.y = 0.0;
   command.linear.z = 0.0;
 
-  command.angular.x = 0.1;
+  command.angular.x = 0.0;
   command.angular.y = 0.0;
-  command.angular.z = 0.0;
+  command.angular.z = 0.1;
 
   while (1) {
     publisher->publish(command);


### PR DESCRIPTION
Publish z component instead of x (already fixed on rolling)