### PR TITLE
Set open_loop to false in diff_drive_controller.yaml

### DIFF
--- a/gz_ros2_control_demos/config/diff_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/diff_drive_controller.yaml
@@ -25,7 +25,7 @@
     pose_covariance_diagonal : [0.001, 0.001, 0.0, 0.0, 0.0, 0.01]
     twist_covariance_diagonal: [0.001, 0.0, 0.0, 0.0, 0.0, 0.01]
 
-    open_loop: true
+    open_loop: false
     enable_odom_tf: true
 
     cmd_vel_timeout: 0.5


### PR DESCRIPTION
I have set the ``open_loop`` parameter to false in ``diff_drive_controller.yaml``. This allows the controller to get feedback from the joints and output correct odometry. I have also done this to maintain consistency with other demos in this repository.