### PR TITLE
Cleanup old ign_ remnants

### DIFF
--- a/gz_ros2_control/gz_hardware_plugins.xml
+++ b/gz_ros2_control/gz_hardware_plugins.xml
@@ -1,19 +1,13 @@
 <library path="gz_hardware_plugins">
+  <!-- https://docs.ros.org/en/foxy/Tutorials/Beginner-Client-Libraries/Pluginlib.html#plugin-declaration-xml -->
+  <!-- name: There used to be a name attribute, but it is no longer required. -->
+  <!-- TODO(christophfroehlich): remove the name attribute before ROS-K release -->
   <class
     name="gz_ros2_control/GazeboSimSystem"
     type="gz_ros2_control::GazeboSimSystem"
     base_class_type="gz_ros2_control::GazeboSimSystemInterface">
     <description>
-      GazeboPositionJoint
+      ros2_control hardware component to be loaded by the gazebo plugin.
     </description>
   </class>
-  <class
-     name="ign_ros2_control/IgnitionSystem"
-     type="gz_ros2_control::GazeboSimSystem"
-     base_class_type="gz_ros2_control::GazeboSimSystemInterface">
-     <description>
-       GazeboPositionJoint
-     </description>
-   </class>
-
 </library>

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -537,6 +537,3 @@ GZ_ADD_PLUGIN(
   gz_ros2_control::GazeboSimROS2ControlPlugin::ISystemConfigure,
   gz_ros2_control::GazeboSimROS2ControlPlugin::ISystemPreUpdate,
   gz_ros2_control::GazeboSimROS2ControlPlugin::ISystemPostUpdate)
-GZ_ADD_PLUGIN_ALIAS(
-  gz_ros2_control::GazeboSimROS2ControlPlugin,
-  "ign_ros2_control::IgnitionROS2ControlPlugin")


### PR DESCRIPTION
Let's remove this in rolling: I think this wasn't working anyways, at least I was not able to launch the ign_ros2_control_demos with this setup.

@ahcorde not sure if we should cleanup this in jazzy as well, or make the ign_ plugins working on jazzy by cherry-picking https://github.com/ros-controls/gz_ros2_control/pull/515/commits/8a3bfe9ed06c778e2bfdd325c8e4083e0f4d8cec from #515