### PR TITLE
Add shim to deprecated ign_ros2_control_demos package

### DIFF
--- a/gz_ros2_control_tests/package.xml
+++ b/gz_ros2_control_tests/package.xml
@@ -13,6 +13,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>gz_ros2_control_demos</test_depend>
+  <test_depend>ign_ros2_control_demos</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>

--- a/gz_ros2_control_tests/tests/CMakeLists.txt
+++ b/gz_ros2_control_tests/tests/CMakeLists.txt
@@ -4,6 +4,10 @@ add_launch_test(position_test.py
   TIMEOUT 50
 )
 
+add_launch_test(position_test_backward_compatibility.py
+  TIMEOUT 50
+)
+
 add_launch_test(velocity_test.py
   TIMEOUT 50
 )

--- a/gz_ros2_control_tests/tests/position_test_backward_compatibility.py
+++ b/gz_ros2_control_tests/tests/position_test_backward_compatibility.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright 2023 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+from controller_manager.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running
+)
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+import launch_testing
+from launch_testing.actions import ReadyToTest
+from launch_testing.util import KeepAliveProc
+from launch_testing_ros import WaitForTopics
+import psutil
+import pytest
+import rclpy
+from rosgraph_msgs.msg import Clock
+
+
+# This function specifies the processes to be run for our test
+@pytest.mark.rostest
+def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
+    proc_env = os.environ.copy()
+    proc_env['PYTHONUNBUFFERED'] = '1'
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory('ign_ros2_control_demos'),
+                'launch/cart_example_position.launch.py',
+            )
+        ),
+        launch_arguments={'gz_args': '--headless-rendering -s'}.items(),
+    )
+
+    return LaunchDescription([launch_include, KeepAliveProc(), ReadyToTest()])
+
+
+class TestFixture(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        for proc in psutil.process_iter():
+            # check whether the process name matches
+            if proc.name() == 'ruby':
+                proc.kill()
+            if 'gz sim' in proc.name():
+                proc.kill()
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('test_node')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_node_start(self, proc_output):
+        check_node_running(self.node, 'robot_state_publisher')
+
+    def test_clock(self):
+        topic_list = [('/clock', Clock)]
+        with WaitForTopics(topic_list, timeout=10.0):
+            print('/clock is receiving messages!')
+
+    def test_check_if_msgs_published(self):
+        check_if_js_published(
+            '/joint_states',
+            [
+                'slider_to_cart',
+            ],
+        )
+
+    def test_arm(self, launch_service, proc_info, proc_output):
+
+        # Check if the controllers are running
+        cnames = ['joint_trajectory_controller', 'joint_state_broadcaster']
+        check_controllers_running(self.node, cnames)
+
+        proc_action = Node(
+            package='ign_ros2_control_demos',
+            executable='example_position',
+            output='screen',
+        )
+
+        with launch_testing.tools.launch_process(
+            launch_service, proc_action, proc_info, proc_output
+        ):
+            proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
+            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
+                                                   allowable_exit_codes=[0])

--- a/ign_ros2_control_demos/CHANGELOG.rst
+++ b/ign_ros2_control_demos/CHANGELOG.rst
@@ -1,0 +1,169 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ign_ros2_control_demos
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.7.12 (2025-02-20)
+-------------------
+
+0.7.11 (2025-02-07)
+-------------------
+* Update diff_drive_controller.yaml (`#494 <https://github.com/ros-controls/gz_ros2_control/issues/494>`_) (`#497 <https://github.com/ros-controls/gz_ros2_control/issues/497>`_)
+  (cherry picked from commit 135332632bd340f17eeb0930b0d46b30fb956ebb)
+  Co-authored-by: Aarav Gupta <amronos275@gmail.com>
+* Contributors: mergify[bot]
+
+0.7.10 (2025-02-05)
+-------------------
+* Publish z component instead of x (`#479 <https://github.com/ros-controls/gz_ros2_control/issues/479>`_)
+* Fix ackermann demo (`#468 <https://github.com/ros-controls/gz_ros2_control/issues/468>`_)
+* Add a namespaced example (`#457 <https://github.com/ros-controls/gz_ros2_control/issues/457>`_) (`#461 <https://github.com/ros-controls/gz_ros2_control/issues/461>`_)
+* Add missing bridges for simulation time (backport `#443 <https://github.com/ros-controls/gz_ros2_control/issues/443>`_) (`#446 <https://github.com/ros-controls/gz_ros2_control/issues/446>`_)
+* Fix docs on humble (`#365 <https://github.com/ros-controls/gz_ros2_control/issues/365>`_)
+* fixed robot name (`#358 <https://github.com/ros-controls/gz_ros2_control/issues/358>`_) (`#360 <https://github.com/ros-controls/gz_ros2_control/issues/360>`_)
+* Contributors: Christoph Fröhlich, mergify[bot]
+
+0.7.9 (2024-07-02)
+------------------
+* [Backport humble]  Ackermann steering example (`#352 <https://github.com/ros-controls/gz_ros2_control/issues/352>`_)
+  Co-authored-by: huzaifa <84243533+huzzu7@users.noreply.github.com>
+* Fixed pendulum examples (`#353 <https://github.com/ros-controls/gz_ros2_control/issues/353>`_)
+* Rename variable in launch file (`#327 <https://github.com/ros-controls/gz_ros2_control/issues/327>`_) (`#338 <https://github.com/ros-controls/gz_ros2_control/issues/338>`_)
+  Co-authored-by: Alejandro Hernández Cordero <ahcorde@gmail.com>
+  (cherry picked from commit cd0b002c49e71be459f4e9f0a063b97fed195b28)
+  Co-authored-by: Christoph Fröhlich <christophfroehlich@users.noreply.github.com>
+* added color definitions (`#310 <https://github.com/ros-controls/gz_ros2_control/issues/310>`_) (`#312 <https://github.com/ros-controls/gz_ros2_control/issues/312>`_)
+  (cherry picked from commit 7cb6fd901f373d6fcfa75ef23e43c6b9d7b186a7)
+  Co-authored-by: Reza Kermani <kermani.areza@gmail.com>
+* Contributors: Alejandro Hernández Cordero, mergify[bot]
+
+0.7.8 (2024-05-14)
+------------------
+* Update pendulum-example  (`#301 <https://github.com/ros-controls/gz_ros2_control/issues/301>`_) (`#303 <https://github.com/ros-controls/gz_ros2_control/issues/303>`_)
+  * Change initial pose of pendulum
+  * Make position and effort version of pendulum equal
+  (cherry picked from commit 1e7721409e5e3d2c583868353a09929ca37bf860)
+  Co-authored-by: Christoph Fröhlich <christophfroehlich@users.noreply.github.com>
+* Add cart-pole demo (`#289 <https://github.com/ros-controls/gz_ros2_control/issues/289>`_) (`#290 <https://github.com/ros-controls/gz_ros2_control/issues/290>`_)
+  (cherry picked from commit 27af2108e77420dc46c83ac31658fccb67e33911)
+  # Conflicts:
+  #	ign_ros2_control_demos/launch/pendulum_example_effort.launch.py
+  #	ign_ros2_control_demos/launch/pendulum_example_position.launch.py
+  #	ign_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
+  #	ign_ros2_control_demos/urdf/test_pendulum_position.xacro.urdf
+  Co-authored-by: Christoph Fröhlich <christophfroehlich@users.noreply.github.com>
+* Contributors: mergify[bot]
+
+0.7.7 (2024-04-09)
+------------------
+
+0.7.6 (2024-03-21)
+------------------
+* Add `ros_gz_bridge` as dependency to demos (backport `#256 <https://github.com/ros-controls/gz_ros2_control/issues/256>`_) (`#257 <https://github.com/ros-controls/gz_ros2_control/issues/257>`_)
+  * Add dep (`#256 <https://github.com/ros-controls/gz_ros2_control/issues/256>`_)
+  (cherry picked from commit b35100db16e80ffb574c0266321800e2197136c3)
+  # Conflicts:
+  #	ign_ros2_control_demos/package.xml
+  * fixed merge
+  ---------
+  Co-authored-by: Christoph Fröhlich <christophfroehlich@users.noreply.github.com>
+  Co-authored-by: Alejandro Hernández Cordero <ahcorde@gmail.com>
+* Contributors: mergify[bot]
+
+0.7.4 (2024-01-24)
+------------------
+
+0.7.3 (2024-01-04)
+------------------
+* Removed cartpole files
+* Rename cartpole with cart (backport `#214 <https://github.com/ros-controls/gz_ros2_control/issues/214>`_) (`#217 <https://github.com/ros-controls/gz_ros2_control/issues/217>`_)
+  Co-authored-by: Alejandro Hernández Cordero <ahcorde@gmail.com>
+* Contributors: Alejandro Hernández Cordero, mergify[bot]
+
+0.7.2 (2024-01-04)
+------------------
+* Update diff_drive_example.launch.py (`#207 <https://github.com/ros-controls/gz_ros2_control/issues/207>`_)
+* Cleanup controller config (backport `#180 <https://github.com/ros-controls/gz_ros2_control/issues/180>`_) (`#181 <https://github.com/ros-controls/gz_ros2_control/issues/181>`_)
+  * Cleanup controller config (`#180 <https://github.com/ros-controls/gz_ros2_control/issues/180>`_)
+  (cherry picked from commit 223174515a64008b2ffef5b730c4c61cc78ff8bc)
+* Contributors: Jakub Delicat, mergify[bot]
+
+0.7.1 (2023-08-23)
+------------------
+* Set C++ version to 17 (`#171 <https://github.com/ros-controls/gz_ros2_control/issues/171>`_) (`#174 <https://github.com/ros-controls/gz_ros2_control/issues/174>`_)
+  (cherry picked from commit 353b5a001733612241049557a907f835b53f35ac)
+  Co-authored-by: Alejandro Hernández Cordero <ahcorde@gmail.com>
+* Update diff_drive_controller_velocity.yaml (`#172 <https://github.com/ros-controls/gz_ros2_control/issues/172>`_) (`#173 <https://github.com/ros-controls/gz_ros2_control/issues/173>`_)
+  (cherry picked from commit 7559d9bfe9dc836a7fc4907cc234554600e54b14)
+  Co-authored-by: Alejandro Hernández Cordero <ahcorde@gmail.com>
+* Contributors: Alejandro Hernández Cordero, mergify[bot]
+
+0.5.0 (2023-05-23)
+------------------
+* Clean shutdown example position (`#135 <https://github.com/ros-controls/gz_ros2_control/issues/135>`_) (`#139 <https://github.com/ros-controls/gz_ros2_control/issues/139>`_)
+* Fixed /clock with gz_ros2_bridge (`#137 <https://github.com/ros-controls/gz_ros2_control/issues/137>`_) (`#138 <https://github.com/ros-controls/gz_ros2_control/issues/138>`_)
+* Contributors: mergify[bot]
+
+0.4.4 (2023-03-28)
+------------------
+* Merge pull request `#121 <https://github.com/ros-controls/gz_ros2_control/issues/121>`_ from livanov93/port-master-to-humble
+* Fix gripper mimic joint example.
+* Pre-commit fix for tricycle configuration.
+* Replace ros_ign_gazebo with ros_gz_sim
+* use ros_gz_sim
+* Fix Docker entrypoint and add launch CLI to dependencites (`#84 <https://github.com/ros-controls/gz_ros2_control/issues/84>`_)
+* Add support for mimic joints. (`#33 <https://github.com/ros-controls/gz_ros2_control/issues/33>`_)
+* Add tricycle demo (`#80 <https://github.com/ros-controls/gz_ros2_control/issues/80>`_)
+* Fix setting initial values if command interfaces are not defined. (`#73 <https://github.com/ros-controls/gz_ros2_control/issues/73>`_)
+* fix demo launch (`#75 <https://github.com/ros-controls/gz_ros2_control/issues/75>`_)
+* Contributors: Alejandro Hernández Cordero, Andrej Orsula, Bence Magyar, Denis Štogl, Ian Chen, Krzysztof Wojciechowski, Lovro Ivanov, Maciej Bednarczyk, Polgár András, Tony Najjar
+
+0.4.3 (2023-02-16)
+------------------
+* Add tricycle example to the `humble` branch `#119 <https://github.com/ros-controls/gz_ros2_control/issues/119>`_ from azazdeaz/humble
+* Replace ros_ign_gazebo with ros_gz_sim
+* Add tricycle demo (`#80 <https://github.com/ros-controls/gz_ros2_control/issues/80>`_)
+* Fix example demos in humble branch `#118 <https://github.com/ros-controls/gz_ros2_control/issues/118>`_ from iche033/iche033/fix_humble_demos
+* use ros_gz_sim
+* fix demo launch (`#75 <https://github.com/ros-controls/gz_ros2_control/issues/75>`_)
+* Adjust URLs (`#65 <https://github.com/ros-controls/gz_ros2_control/issues/65>`_)
+* ign_ros2_control_demos: Install urdf dir (`#61 <https://github.com/ros-controls/gz_ros2_control/issues/61>`_)
+* Remove URDF dependency (`#56 <https://github.com/ros-controls/gz_ros2_control/issues/56>`_)
+* Use Ubuntu Jammy in CI (`#47 <https://github.com/ros-controls/gz_ros2_control/issues/47>`_)
+* Add support for initial_values for hardware interfaces when starting simulation. (`#27 <https://github.com/ros-controls/gz_ros2_control/issues/27>`_)
+* Contributors: Alejandro Hernández Cordero, Andrej Orsula, Bence Magyar, Denis Štogl, Maciej Bednarczyk, ahcorde
+
+0.4.0 (2022-03-18)
+------------------
+
+0.3.0 (2022-03-16)
+------------------
+
+0.2.0 (2022-02-17)
+------------------
+* Merge pull request `#36 <https://github.com/ignitionrobotics/ign_ros2_control/issues/36>`_ from ignitionrobotics/ahcorde/foxy_to_galactic
+  Foxy -> Galactic
+* Fixed galactic dependency
+* Merge remote-tracking branch 'origin/foxy' into ahcorde/foxy_to_galactic
+* Contributors: Alejandro Hernández Cordero
+
+0.1.2 (2022-02-14)
+------------------
+* Updated docs and renamed diff drive launch file (`#32 <https://github.com/ignitionrobotics/ign_ros2_control/issues/32>`_)
+  Co-authored-by: Denis Štogl <denis@stogl.de>
+* Added Diff drive example (`#28 <https://github.com/ignitionrobotics/ign_ros2_control/issues/28>`_)
+* Contributors: Alejandro Hernández Cordero
+
+0.1.1 (2022-01-07)
+------------------
+* Change package names from ignition\_ to ign\_ (`#19 <https://github.com/ignitionrobotics/ign_ros2_control/issues/19>`_)
+  * Change package names from ignition\_ to ign\_
+* Added missing dependencies to package.xml (`#18 <https://github.com/ignitionrobotics/ign_ros2_control/pull/21>`_)
+* Contributors: Alejandro Hernández Cordero
+
+0.1.0 (2022-01-05)
+------------------
+* Ignition ros2 control (`#1 <https://github.com/ignitionrobotics/ign_ros2_control/issues/1>`_)
+  Co-authored-by: ahcorde <ahcorde@gmail.com>
+  Co-authored-by: Louise Poubel <louise@openrobotics.org>
+  Co-authored-by: Vatan Aksoy Tezer <vatan@picknik.ai>
+* Contributors: Alejandro Hernández Cordero, Louise Poubel, Vatan Aksoy Tezer

--- a/ign_ros2_control_demos/CMakeLists.txt
+++ b/ign_ros2_control_demos/CMakeLists.txt
@@ -1,0 +1,95 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(ign_ros2_control_demos)
+
+# Default to C11
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 11)
+endif()
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+if(NOT WIN32)
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+find_package(rclcpp REQUIRED)
+
+install(DIRECTORY
+  launch
+  urdf
+  DESTINATION share/${PROJECT_NAME}/
+)
+
+
+add_executable(example_position examples/example_position.cpp)
+ament_target_dependencies(example_position
+  ament_index_cpp
+  rclcpp
+)
+
+# use the same example_position.cpp for example_velocity
+add_executable(example_velocity examples/example_position.cpp)
+ament_target_dependencies(example_velocity
+  ament_index_cpp
+  rclcpp
+)
+
+# use the same example_position.cpp for example_effort
+add_executable(example_effort examples/example_position.cpp)
+ament_target_dependencies(example_effort
+  ament_index_cpp
+  rclcpp
+)
+
+add_executable(example_diff_drive examples/example_diff_drive.cpp)
+ament_target_dependencies(example_diff_drive
+  ament_index_cpp
+  rclcpp
+)
+
+add_executable(example_tricycle_drive examples/example_tricycle_drive.cpp)
+ament_target_dependencies(example_tricycle_drive
+  ament_index_cpp
+  rclcpp
+)
+
+add_executable(example_ackermann_drive examples/example_ackermann_drive.cpp)
+ament_target_dependencies(example_ackermann_drive
+  ament_index_cpp
+  rclcpp
+)
+
+add_executable(example_gripper examples/example_gripper.cpp)
+ament_target_dependencies(example_gripper
+  ament_index_cpp
+  rclcpp
+)
+
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+## Install
+install(
+  TARGETS
+    example_position
+    example_velocity
+    example_effort
+    example_diff_drive
+    example_tricycle_drive
+    example_ackermann_drive
+    example_gripper
+  DESTINATION
+    lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/ign_ros2_control_demos/CMakeLists.txt
+++ b/ign_ros2_control_demos/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-find_package(rclcpp REQUIRED)
 
 install(DIRECTORY
   launch
@@ -29,45 +28,38 @@ install(DIRECTORY
 add_executable(example_position examples/example_position.cpp)
 ament_target_dependencies(example_position
   ament_index_cpp
-  rclcpp
 )
 
 # use the same example_position.cpp for example_velocity
 add_executable(example_velocity examples/example_position.cpp)
 ament_target_dependencies(example_velocity
   ament_index_cpp
-  rclcpp
 )
 
 # use the same example_position.cpp for example_effort
 add_executable(example_effort examples/example_position.cpp)
 ament_target_dependencies(example_effort
   ament_index_cpp
-  rclcpp
 )
 
 add_executable(example_diff_drive examples/example_diff_drive.cpp)
 ament_target_dependencies(example_diff_drive
   ament_index_cpp
-  rclcpp
 )
 
 add_executable(example_tricycle_drive examples/example_tricycle_drive.cpp)
 ament_target_dependencies(example_tricycle_drive
   ament_index_cpp
-  rclcpp
 )
 
 add_executable(example_ackermann_drive examples/example_ackermann_drive.cpp)
 ament_target_dependencies(example_ackermann_drive
   ament_index_cpp
-  rclcpp
 )
 
 add_executable(example_gripper examples/example_gripper.cpp)
 ament_target_dependencies(example_gripper
   ament_index_cpp
-  rclcpp
 )
 
 

--- a/ign_ros2_control_demos/examples/example_ackermann_drive.cpp
+++ b/ign_ros2_control_demos/examples/example_ackermann_drive.cpp
@@ -1,0 +1,45 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shim to redirect "ign_ros2_control_demos example_ackermann_drive" call
+// to "gz_ros2_control_demos example_ackermann_drive"
+
+#include <stdlib.h>
+
+#include <sstream>
+#include <iostream>
+
+#include <ament_index_cpp/get_package_prefix.hpp>
+
+
+int main(int argc, char * argv[])
+{
+  std::stringstream cli_call;
+
+  cli_call << ament_index_cpp::get_package_prefix("gz_ros2_control_demos")
+           << "/lib/gz_ros2_control_demos/example_ackermann_drive";
+
+  if (argc > 1) {
+    for (int i = 1; i < argc; i++) {
+      cli_call << " " << argv[i];
+    }
+  }
+
+  std::cerr << "[ign_ros2_control_demos] is deprecated! "
+            << "Redirecting to use [gz_ros2_control_demos] instead!"
+            << std::endl << std::endl;
+  system(cli_call.str().c_str());
+
+  return 0;
+}

--- a/ign_ros2_control_demos/examples/example_diff_drive.cpp
+++ b/ign_ros2_control_demos/examples/example_diff_drive.cpp
@@ -1,0 +1,45 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shim to redirect "ign_ros2_control_demos example_diff_drive" call
+// to "gz_ros2_control_demos example_diff_drive"
+
+#include <stdlib.h>
+
+#include <sstream>
+#include <iostream>
+
+#include <ament_index_cpp/get_package_prefix.hpp>
+
+
+int main(int argc, char * argv[])
+{
+  std::stringstream cli_call;
+
+  cli_call << ament_index_cpp::get_package_prefix("gz_ros2_control_demos")
+           << "/lib/gz_ros2_control_demos/example_diff_drive";
+
+  if (argc > 1) {
+    for (int i = 1; i < argc; i++) {
+      cli_call << " " << argv[i];
+    }
+  }
+
+  std::cerr << "[ign_ros2_control_demos] is deprecated! "
+            << "Redirecting to use [gz_ros2_control_demos] instead!"
+            << std::endl << std::endl;
+  system(cli_call.str().c_str());
+
+  return 0;
+}

--- a/ign_ros2_control_demos/examples/example_gripper.cpp
+++ b/ign_ros2_control_demos/examples/example_gripper.cpp
@@ -1,0 +1,48 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Author: Denis Štogl (Stogl Robotics Consulting)
+//
+
+// Shim to redirect "ign_ros2_control_demos example_gripper" call
+// to "gz_ros2_control_demos example_gripper"
+
+#include <stdlib.h>
+
+#include <sstream>
+#include <iostream>
+
+#include <ament_index_cpp/get_package_prefix.hpp>
+
+
+int main(int argc, char * argv[])
+{
+  std::stringstream cli_call;
+
+  cli_call << ament_index_cpp::get_package_prefix("gz_ros2_control_demos")
+           << "/lib/gz_ros2_control_demos/example_gripper";
+
+  if (argc > 1) {
+    for (int i = 1; i < argc; i++) {
+      cli_call << " " << argv[i];
+    }
+  }
+
+  std::cerr << "[ign_ros2_control_demos] is deprecated! "
+            << "Redirecting to use [gz_ros2_control_demos] instead!"
+            << std::endl << std::endl;
+  system(cli_call.str().c_str());
+
+  return 0;
+}

--- a/ign_ros2_control_demos/examples/example_position.cpp
+++ b/ign_ros2_control_demos/examples/example_position.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shim to redirect "ign_ros2_control_demos example_position" call
+// to "gz_ros2_control_demos example_position"
+
+#include <stdlib.h>
+
+#include <sstream>
+#include <iostream>
+
+#include <ament_index_cpp/get_package_prefix.hpp>
+
+
+int main(int argc, char * argv[])
+{
+  std::stringstream cli_call;
+
+  cli_call << ament_index_cpp::get_package_prefix("gz_ros2_control_demos")
+           << "/lib/gz_ros2_control_demos/example_position";
+
+  if (argc > 1) {
+    for (int i = 1; i < argc; i++) {
+      cli_call << " " << argv[i];
+    }
+  }
+
+  std::cerr << "[ign_ros2_control_demos] is deprecated! "
+            << "Redirecting to use [gz_ros2_control_demos] instead!"
+            << std::endl << std::endl;
+  system(cli_call.str().c_str());
+
+  return 0;
+}

--- a/ign_ros2_control_demos/examples/example_tricycle_drive.cpp
+++ b/ign_ros2_control_demos/examples/example_tricycle_drive.cpp
@@ -1,0 +1,45 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shim to redirect "ign_ros2_control_demos example_tricycle_drive" call
+// to "gz_ros2_control_demos example_tricycle_drive"
+
+#include <stdlib.h>
+
+#include <sstream>
+#include <iostream>
+
+#include <ament_index_cpp/get_package_prefix.hpp>
+
+
+int main(int argc, char * argv[])
+{
+  std::stringstream cli_call;
+
+  cli_call << ament_index_cpp::get_package_prefix("gz_ros2_control_demos")
+           << "/lib/gz_ros2_control_demos/example_tricycle_drive";
+
+  if (argc > 1) {
+    for (int i = 1; i < argc; i++) {
+      cli_call << " " << argv[i];
+    }
+  }
+
+  std::cerr << "[ign_ros2_control_demos] is deprecated! "
+            << "Redirecting to use [gz_ros2_control_demos] instead!"
+            << std::endl << std::endl;
+  system(cli_call.str().c_str());
+
+  return 0;
+}

--- a/ign_ros2_control_demos/launch/ackermann_drive_example.launch.py
+++ b/ign_ros2_control_demos/launch/ackermann_drive_example.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'ackermann_drive_example.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/launch/cart_example_effort.launch.py
+++ b/ign_ros2_control_demos/launch/cart_example_effort.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'cart_example_effort.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/launch/cart_example_position.launch.py
+++ b/ign_ros2_control_demos/launch/cart_example_position.launch.py
@@ -1,0 +1,123 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    # Launch Arguments
+    use_sim_time = LaunchConfiguration('use_sim_time', default=True)
+    gz_args = LaunchConfiguration('gz_args', default='')
+
+    # Get URDF via xacro
+    robot_description_content = Command(
+        [
+            PathJoinSubstitution([FindExecutable(name='xacro')]),
+            ' ',
+            PathJoinSubstitution(
+                [FindPackageShare('ign_ros2_control_demos'),
+                 'urdf', 'test_cart_position.xacro.urdf']
+            ),
+        ]
+    )
+    robot_description = {'robot_description': robot_description_content}
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare('gz_ros2_control_demos'),
+            'config',
+            'cart_controller_position.yaml',
+        ]
+    )
+
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[robot_description]
+    )
+
+    gz_spawn_entity = Node(
+        package='ros_gz_sim',
+        executable='create',
+        output='screen',
+        arguments=['-topic', 'robot_description',
+                   '-name', 'cart', '-allow_renaming', 'true'],
+    )
+
+    joint_state_broadcaster_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=['joint_state_broadcaster',
+                   ],
+    )
+    joint_trajectory_controller_spawner = Node(
+        package='controller_manager',
+        executable='spawner',
+        arguments=[
+            'joint_trajectory_controller',
+            '--param-file',
+            robot_controllers,
+            ],
+    )
+
+    # Bridge
+    bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        arguments=['/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock'],
+        output='screen'
+    )
+
+    return LaunchDescription([
+        # Launch gazebo environment
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
+                                       'launch',
+                                       'gz_sim.launch.py'])]),
+            launch_arguments=[('gz_args', [gz_args, ' -r -v 1 empty.sdf'])]),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=gz_spawn_entity,
+                on_exit=[joint_state_broadcaster_spawner],
+            )
+        ),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action=joint_state_broadcaster_spawner,
+                on_exit=[joint_trajectory_controller_spawner],
+            )
+        ),
+        bridge,
+        node_robot_state_publisher,
+        gz_spawn_entity,
+        # Launch Arguments
+        DeclareLaunchArgument(
+            'use_sim_time',
+            default_value=use_sim_time,
+            description='If true, use simulated clock'),
+    ])

--- a/ign_ros2_control_demos/launch/cart_example_velocity.launch.py
+++ b/ign_ros2_control_demos/launch/cart_example_velocity.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'cart_example_velocity.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/launch/diff_drive_example.launch.py
+++ b/ign_ros2_control_demos/launch/diff_drive_example.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'diff_drive_example.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/launch/diff_drive_example_namespaced.launch.py
+++ b/ign_ros2_control_demos/launch/diff_drive_example_namespaced.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2024 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'diff_drive_example_namespaced.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
+++ b/ign_ros2_control_demos/launch/gripper_mimic_joint_example.launch.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Denis Stogl (Stogl Robotics Consulting)
+#
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'gripper_mimic_joint_example.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/launch/pendulum_example_effort.launch.py
+++ b/ign_ros2_control_demos/launch/pendulum_example_effort.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2024 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'pendulum_example_effort.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/launch/pendulum_example_position.launch.py
+++ b/ign_ros2_control_demos/launch/pendulum_example_position.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2024 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'pendulum_example_position.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/launch/tricycle_drive_example.launch.py
+++ b/ign_ros2_control_demos/launch/tricycle_drive_example.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    print("###########################################################################")
+    print("This launch file is deprecated. Please use the one in gz_ros2_control_demos")
+    print("###########################################################################")
+
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare('gz_ros2_control_demos'),
+                 'launch', 'tricycle_drive_example.launch.py']
+            )
+        ),
+    )
+
+    return LaunchDescription([launch_include])

--- a/ign_ros2_control_demos/package.xml
+++ b/ign_ros2_control_demos/package.xml
@@ -20,6 +20,9 @@
   <depend>ament_index_cpp</depend>
   <depend>gz_ros2_control_demos</depend>
 
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ign_ros2_control_demos/package.xml
+++ b/ign_ros2_control_demos/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>ign_ros2_control_demos</name>
+  <version>0.7.12</version>
+  <description>Shim package for gz_ros2_control_demos</description>
+
+  <maintainer email="ahcorde@osrfoundation.org">Alejandro Hernandez</maintainer>
+
+  <license>Apache License 2.0</license>
+
+
+  <url type="website">https://github.com/ros-controls/gz_ros2_control/blob/master/README.md</url>
+  <url type="bugtracker">https://github.com/ros-controls/gz_ros2_control/issues</url>
+  <url type="repository">https://github.com/ros-controls/gz_ros2_control</url>
+
+  <author>Alejandro Hernández</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>ament_index_cpp</depend>
+  <depend>gz_ros2_control_demos</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ign_ros2_control_demos/urdf/test_cart_position.xacro.urdf
+++ b/ign_ros2_control_demos/urdf/test_cart_position.xacro.urdf
@@ -1,0 +1,84 @@
+<?xml version="1.0" ?>
+<robot name="cartopole">
+  <link name="world"/>
+  <link name="slideBar">
+    <visual>
+      <geometry>
+        <box size="30 0.05 0.05"/>
+      </geometry>
+      <origin xyz="0 0 0"/>
+    </visual>
+    <inertial>
+      <mass value="100"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+    </inertial>
+  </link>
+  <link name="cart">
+    <visual>
+      <geometry>
+        <box size="0.5 0.5 0.2"/>
+      </geometry>
+      <origin xyz="0 0 0"/>
+    </visual>
+    <inertial>
+      <mass value="1"/>
+      <inertia ixx="1.0" ixy="0.0" ixz="0.0" iyy="1.0" iyz="0.0" izz="1.0"/>
+    </inertial>
+  </link>
+  <joint name="world_to_base" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 1"/>
+    <parent link="world"/>
+    <child link="slideBar"/>
+  </joint>
+  <joint name="slider_to_cart" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <origin xyz="0.0 0.0 0.0"/>
+    <parent link="slideBar"/>
+    <child link="cart"/>
+    <limit effort="1000.0" lower="-15" upper="15" velocity="30"/>
+    <dynamics damping="0.0" friction="0.0"/>
+  </joint>
+
+  <ros2_control name="IgnitionSystem" type="system">
+    <hardware>
+      <plugin>ign_ros2_control/IgnitionSystem</plugin>
+    </hardware>
+    <joint name="slider_to_cart">
+      <command_interface name="position">
+        <param name="min">-15</param>
+        <param name="max">15</param>
+      </command_interface>
+      <state_interface name="position">
+        <param name="initial_value">-5.0</param>
+      </state_interface>
+      <state_interface name="velocity"/>
+      <state_interface name="effort"/>
+    </joint>
+  </ros2_control>
+
+  <gazebo reference="slideBar">
+    <visual>
+      <material>
+        <ambient>0 0.8 0 1</ambient>
+        <diffuse>0 0.8 0 1</diffuse>
+        <specular>0 0.8 0 1</specular>
+      </material>
+    </visual>
+  </gazebo>
+
+  <gazebo reference="cart">
+    <visual>
+      <material>
+        <ambient>0 0 0.8 1</ambient>
+        <diffuse>0 0 0.8 1</diffuse>
+        <specular>0 0 0.8 1</specular>
+      </material>
+    </visual>
+  </gazebo>
+
+  <gazebo>
+    <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+      <parameters>$(find gz_ros2_control_demos)/config/cart_controller_position.yaml</parameters>
+    </plugin>
+  </gazebo>
+</robot>


### PR DESCRIPTION
- launch files point to equivalent in gz_ros2_control_demos
```
$ ros2 launch ign_ros2_control_demos tricycle_drive_example.launch.py 
[INFO] [launch]: All log files can be found below /home/vscode/.ros/log/2025-03-25-12-37-06-429043-L1CDS09-229590
[INFO] [launch]: Default logging verbosity is set to INFO
###########################################################################
This launch file is deprecated. Please use the one in gz_ros2_control_demos
###########################################################################
```
- executables are shims to equivalent in gz_ros2_control_demos:
```
$ ros2 run ign_ros2_control_demos example_tricycle_drive 
[ign_ros2_control_demos] is deprecated! Redirecting to use [gz_ros2_control_demos] instead!

[INFO] [1742906234.555302465] [tricycle_drive_test_node]: node created
```
- a test is added to gz_ros2_control_tests to see if a URDF with deprecated ign_ros2_control plugin is still loading.