### PR TITLE
Temporary fix to change controller-ros-args to a single argument for launch files

### DIFF
--- a/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
@@ -79,7 +79,7 @@ def generate_launch_description():
                    robot_controllers,
                    '--controller-ros-args',
                    ('-r /ackermann_steering_controller/tf_odometry:=/tf '
-                   '-r /ackermann_steering_controller/reference:=/cmd_vel')
+                    '-r /ackermann_steering_controller/reference:=/cmd_vel')
                    ],
     )
 

--- a/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
@@ -78,8 +78,7 @@ def generate_launch_description():
                    '--param-file',
                    robot_controllers,
                    '--controller-ros-args',
-                   '-r /ackermann_steering_controller/tf_odometry:=/tf',
-                   '-r /ackermann_steering_controller/reference:=/cmd_vel'
+                   '-r /ackermann_steering_controller/tf_odometry:=/tf -r /ackermann_steering_controller/reference:=/cmd_vel'
                    ],
     )
 

--- a/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
@@ -78,7 +78,8 @@ def generate_launch_description():
                    '--param-file',
                    robot_controllers,
                    '--controller-ros-args',
-                   '-r /ackermann_steering_controller/tf_odometry:=/tf -r /ackermann_steering_controller/reference:=/cmd_vel'
+                   ('-r /ackermann_steering_controller/tf_odometry:=/tf '
+                   '-r /ackermann_steering_controller/reference:=/cmd_vel')
                    ],
     )
 

--- a/gz_ros2_control_demos/launch/mecanum_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/mecanum_drive_example.launch.py
@@ -75,8 +75,7 @@ def generate_launch_description():
             '--param-file',
             robot_controllers,
             '--controller-ros-args',
-            '-r /mecanum_drive_controller/tf_odometry:=/tf',
-            '-r /mecanum_drive_controller/reference:=/cmd_vel',
+            '-r /mecanum_drive_controller/tf_odometry:=/tf -r /mecanum_drive_controller/reference:=/cmd_vel'
         ],
     )
 

--- a/gz_ros2_control_demos/launch/mecanum_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/mecanum_drive_example.launch.py
@@ -76,7 +76,7 @@ def generate_launch_description():
             robot_controllers,
             '--controller-ros-args',
             ('-r /mecanum_drive_controller/tf_odometry:=/tf '
-            '-r /mecanum_drive_controller/reference:=/cmd_vel')
+             '-r /mecanum_drive_controller/reference:=/cmd_vel')
         ],
     )
 

--- a/gz_ros2_control_demos/launch/mecanum_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/mecanum_drive_example.launch.py
@@ -75,7 +75,8 @@ def generate_launch_description():
             '--param-file',
             robot_controllers,
             '--controller-ros-args',
-            '-r /mecanum_drive_controller/tf_odometry:=/tf -r /mecanum_drive_controller/reference:=/cmd_vel'
+            ('-r /mecanum_drive_controller/tf_odometry:=/tf '
+            '-r /mecanum_drive_controller/reference:=/cmd_vel')
         ],
     )
 


### PR DESCRIPTION
This is in response to the issue #532.

It is a temporary fix while until this ros2_control [PR 2150](https://github.com/ros-controls/ros2_control/pull/2150) allows for multiple arguments.
