### PR TITLE
Don't compile ros_gz for harmonic on humble

### DIFF
--- a/.github/workflows/ci-humble.yaml
+++ b/.github/workflows/ci-humble.yaml
@@ -51,7 +51,8 @@ jobs:
           # https://gazebosim.org/docs/harmonic/install_ubuntu/#binary-installation-on-ubuntu
           curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-          export GZ_DEPS="gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge"
+          export GZ_DEPS="gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge ros-humble-ros-gzharmonic-sim"
+          export GZ_DEPS_ROSDEP="ros_gz ros_gz_bridge ros_gz_sim"
         fi
         apt-get update && apt-get upgrade -q -y
         apt-get update && apt-get install -qq -y \
@@ -68,7 +69,7 @@ jobs:
           wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
         fi
         rosdep update --rosdistro humble
-        rosdep install --from-paths ./ -i -y --rosdistro humble
+        rosdep install --from-paths ./ -i -y --rosdistro humble --skip-keys="${GZ_DEPS_ROSDEP}"
     - name: Build project
       id: build
       run: |

--- a/.github/workflows/ci-humble.yaml
+++ b/.github/workflows/ci-humble.yaml
@@ -64,10 +64,6 @@ jobs:
           ${GZ_DEPS}
         cd /home/ros2_ws/src/
         rosdep init
-        if [ "$GZ_VERSION" == "harmonic" ]; then
-          # https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries
-          wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
-        fi
         rosdep update --rosdistro humble
         rosdep install --from-paths ./ -i -y --rosdistro humble --skip-keys="${GZ_DEPS_ROSDEP}"
     - name: Build project

--- a/.github/workflows/ci-humble.yaml
+++ b/.github/workflows/ci-humble.yaml
@@ -51,7 +51,7 @@ jobs:
           # https://gazebosim.org/docs/harmonic/install_ubuntu/#binary-installation-on-ubuntu
           curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-          export GZ_DEPS="gz-harmonic"
+          export GZ_DEPS="gz-harmonic ros-humble-ros-gzharmonic"
         fi
         apt-get update && apt-get upgrade -q -y
         apt-get update && apt-get install -qq -y \
@@ -64,8 +64,6 @@ jobs:
         cd /home/ros2_ws/src/
         rosdep init
         if [ "$GZ_VERSION" == "harmonic" ]; then
-          # https://github.com/gazebosim/ros_gz/tree/ros2#from-source
-          git clone https://github.com/gazebosim/ros_gz/ -b humble
           # https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries
           wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
         fi

--- a/.github/workflows/ci-humble.yaml
+++ b/.github/workflows/ci-humble.yaml
@@ -64,6 +64,10 @@ jobs:
           ${GZ_DEPS}
         cd /home/ros2_ws/src/
         rosdep init
+        if [ "$GZ_VERSION" == "harmonic" ]; then
+          # https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries
+          wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
+        fi
         rosdep update --rosdistro humble
         rosdep install --from-paths ./ -i -y --rosdistro humble --skip-keys="${GZ_DEPS_ROSDEP}"
     - name: Build project

--- a/.github/workflows/ci-humble.yaml
+++ b/.github/workflows/ci-humble.yaml
@@ -51,7 +51,7 @@ jobs:
           # https://gazebosim.org/docs/harmonic/install_ubuntu/#binary-installation-on-ubuntu
           curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-          export GZ_DEPS="gz-harmonic ros-humble-ros-gzharmonic"
+          export GZ_DEPS="gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge"
         fi
         apt-get update && apt-get upgrade -q -y
         apt-get update && apt-get install -qq -y \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ mkdir -p ~/gz_ros2_control_ws/src
 cd ~/gz_ros2_control_ws/src
 git clone https://github.com/ros-controls/gz_ros2_control -b humble
 export GZ_VERSION=harmonic
-rosdep install -r --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
+rosdep install -r --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y --skip-keys="ros_gz_bridge ros_gz_sim"
 cd ~/gz_ros2_control_ws
 colcon build
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd ~/gz_ros2_control_ws
 colcon build
 ```
 
-If you want to use `harmonic`, then follow the instructions in the [official Gazebo Harmonic documentation](https://gazebosim.org/docs/harmonic/ros_installation/#gazebo-harmonic-with-ros-2-humble-or-rolling-use-with-caution) how to install Gazebo Harmonic on ROS 2 humble, i.e, `apt-get install gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge`. Additionally, you need to [install the rosdep rules](https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries) for gazebo harmonic.
+If you want to use `harmonic`, then follow the instructions in the [official Gazebo Harmonic documentation](https://gazebosim.org/docs/harmonic/ros_installation/#gazebo-harmonic-with-ros-2-humble-or-rolling-use-with-caution) how to install Gazebo Harmonic on ROS 2 humble, i.e, `apt-get install gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge`.
 
 Then create a workspace, clone the correct branch of this repo and compile it by setting the environment variable `GZ_VERSION`:
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,13 @@ cd ~/gz_ros2_control_ws
 colcon build
 ```
 
-If you want to use `harmonic`, then follow the instructions in the [official Gazebo Harmonic documentation](https://gazebosim.org/docs/harmonic/ros_installation/#gazebo-harmonic-with-ros-2-humble-or-rolling-use-with-caution) how to install Gazebo Harmonic on ROS 2 humble.
+If you want to use `harmonic`, then follow the instructions in the [official Gazebo Harmonic documentation](https://gazebosim.org/docs/harmonic/ros_installation/#gazebo-harmonic-with-ros-2-humble-or-rolling-use-with-caution) how to install Gazebo Harmonic on ROS 2 humble, i.e, `apt-get install gz-harmonic ros-humble-ros-gzharmonic`. Additionally, you need to [install the rosdep rules](https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries) for gazebo harmonic.
 
 Then create a workspace, clone the correct branch of this repo and compile it by setting the environment variable `GZ_VERSION`:
 
 ```bash
 mkdir -p ~/gz_ros2_control_ws/src
 cd ~/gz_ros2_control_ws/src
-git clone https://github.com/gazebosim/ros_gz/ -b humble # only needed for harmonic
 git clone https://github.com/ros-controls/gz_ros2_control -b humble
 export GZ_VERSION=harmonic
 rosdep install -r --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd ~/gz_ros2_control_ws
 colcon build
 ```
 
-If you want to use `harmonic`, then follow the instructions in the [official Gazebo Harmonic documentation](https://gazebosim.org/docs/harmonic/ros_installation/#gazebo-harmonic-with-ros-2-humble-or-rolling-use-with-caution) how to install Gazebo Harmonic on ROS 2 humble, i.e, `apt-get install gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge`.
+If you want to use `harmonic`, then follow the instructions in the [official Gazebo Harmonic documentation](https://gazebosim.org/docs/harmonic/ros_installation/#gazebo-harmonic-with-ros-2-humble-or-rolling-use-with-caution) how to install Gazebo Harmonic on ROS 2 humble, i.e, `apt-get install gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge`. Additionally, you need to [install the rosdep rules](https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries) for gazebo harmonic.
 
 Then create a workspace, clone the correct branch of this repo and compile it by setting the environment variable `GZ_VERSION`:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd ~/gz_ros2_control_ws
 colcon build
 ```
 
-If you want to use `harmonic`, then follow the instructions in the [official Gazebo Harmonic documentation](https://gazebosim.org/docs/harmonic/ros_installation/#gazebo-harmonic-with-ros-2-humble-or-rolling-use-with-caution) how to install Gazebo Harmonic on ROS 2 humble, i.e, `apt-get install gz-harmonic ros-humble-ros-gzharmonic`. Additionally, you need to [install the rosdep rules](https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries) for gazebo harmonic.
+If you want to use `harmonic`, then follow the instructions in the [official Gazebo Harmonic documentation](https://gazebosim.org/docs/harmonic/ros_installation/#gazebo-harmonic-with-ros-2-humble-or-rolling-use-with-caution) how to install Gazebo Harmonic on ROS 2 humble, i.e, `apt-get install gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge`. Additionally, you need to [install the rosdep rules](https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries) for gazebo harmonic.
 
 Then create a workspace, clone the correct branch of this repo and compile it by setting the environment variable `GZ_VERSION`:
 

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -29,8 +29,12 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>ros_gz_bridge</exec_depend>
-  <exec_depend>ros_gz_sim</exec_depend>
+  <!-- Harmonic -->
+  <exec_depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_bridge</exec_depend>
+  <exec_depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_sim</exec_depend>
+  <!-- Fortress (default) -->
+  <exec_depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_bridge</exec_depend>
+  <exec_depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_sim</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -29,12 +29,8 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <!-- Harmonic -->
-  <exec_depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_bridge</exec_depend>
-  <exec_depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_sim</exec_depend>
-  <!-- Fortress (default) -->
-  <exec_depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_bridge</exec_depend>
-  <exec_depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_sim</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>gz_ros2_control_demos</name>
   <version>0.7.12</version>
   <description>gz_ros2_control_demos</description>
@@ -23,19 +23,18 @@
   <build_depend>rclcpp_action</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <!-- Harmonic -->
-  <depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_bridge</depend>
-  <depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_sim</depend>
-  <!-- Fortress (default) -->
-  <depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_bridge</depend>
-  <depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_sim</depend>
-
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <!-- Harmonic -->
+  <exec_depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_bridge</exec_depend>
+  <exec_depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_sim</exec_depend>
+  <!-- Fortress (default) -->
+  <exec_depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_bridge</exec_depend>
+  <exec_depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_sim</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -23,18 +23,19 @@
   <build_depend>rclcpp_action</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <!-- Harmonic -->
+  <depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_bridge</depend>
+  <depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_sim</depend>
+  <!-- Fortress (default) -->
+  <depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_bridge</depend>
+  <depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_sim</depend>
+
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <!-- Harmonic -->
-  <exec_depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_bridge</exec_depend>
-  <exec_depend condition="$GZ_VERSION == harmonic">ros_gzharmonic_sim</exec_depend>
-  <!-- Fortress (default) -->
-  <exec_depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_bridge</exec_depend>
-  <exec_depend condition="$GZ_VERSION == '' or $GZ_VERSION == fortress">ros_gz_sim</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="3">
+<package format="2">
   <name>gz_ros2_control_demos</name>
   <version>0.7.12</version>
   <description>gz_ros2_control_demos</description>


### PR DESCRIPTION
@federicociresola pointed out that ros-gz is provided as binary already
https://github.com/ros-controls/gz_ros2_control/commit/4c5c0da48ff7ceab5ea70f6ee88196d1838878d7#r154633183