### PR TITLE
Use  `--controller-ros-args` to use parser append action in controller spawner

### DIFF
--- a/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/ackermann_drive_example.launch.py
@@ -79,6 +79,7 @@ def generate_launch_description():
                    robot_controllers,
                    '--controller-ros-args',
                    '-r /ackermann_steering_controller/tf_odometry:=/tf',
+                   '--controller-ros-args',
                    '-r /ackermann_steering_controller/reference:=/cmd_vel'
                    ],
     )

--- a/gz_ros2_control_demos/launch/mecanum_drive_example.launch.py
+++ b/gz_ros2_control_demos/launch/mecanum_drive_example.launch.py
@@ -76,6 +76,7 @@ def generate_launch_description():
             robot_controllers,
             '--controller-ros-args',
             '-r /mecanum_drive_controller/tf_odometry:=/tf',
+            '--controller-ros-args',
             '-r /mecanum_drive_controller/reference:=/cmd_vel',
         ],
     )


### PR DESCRIPTION
This is in response to the issue #532.

This is a fix to align with this ros2_control [PR 2150](https://github.com/ros-controls/ros2_control/pull/2150), which allows for multiple arguments.

This also replaces the old temporary solution [PR 535](https://github.com/ros-controls/gz_ros2_control/pull/535).
