### PR TITLE
Fixed APT Key for Humble

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package provides a Gazebo-Sim system plugin which instantiates a `ros2_cont
 
 ROS version | Gazebo version | Branch | Binaries hosted at | APT key
 -- | -- | -- | -- | --
-Humble | Fortress | [humble](https://github.com/ros-controls/gz_ros2_control/tree/humble) | https://packages.ros.org | `ros-humble-gz-ros2-control`
+Humble | Fortress | [humble](https://github.com/ros-controls/gz_ros2_control/tree/humble) | https://packages.ros.org | `ros-humble-gazebo-ros2-control`
 Humble | Harmonic | [humble](https://github.com/ros-controls/gz_ros2_control/tree/humble) | build from source | -
 Jazzy | Harmonic | [jazzy](https://github.com/ros-controls/gz_ros2_control/tree/jazzy) | https://packages.ros.org | `ros-jazzy-gz-ros2-control`
 Rolling | Ionic | [rolling](https://github.com/ros-controls/gz_ros2_control/tree/rolling) | https://packages.ros.org | `ros-rolling-gz-ros2-control`


### PR DESCRIPTION
Using original APT key from README to install package doesn't work, got:
``` bash
E: Unable to locate package ros2-humble-gz-ros2-control
```
Works with this APT key:
```bash
ros2-humble-gz-ros2-control
```
