### PR TITLE
Use docker images from ros-controls on humble

### DIFF
--- a/.github/workflows/ci-humble.yaml
+++ b/.github/workflows/ci-humble.yaml
@@ -22,10 +22,9 @@ jobs:
           - gz-version: harmonic
             ros-repo-packages: "-testing"
     env:
-      ROS_REPO_PACKAGES: ${{ matrix.ros-repo-packages }}
       GZ_VERSION: ${{ matrix.gz-version }}
     container:
-      image: ubuntu:22.04
+      image: ghcr.io/ros-controls/ros:humble-ubuntu${{ matrix.ros-repo-packages }}
     steps:
     - name: Checkout code
       if: github.event_name != 'schedule'
@@ -39,47 +38,27 @@ jobs:
       id: configure
       shell: bash
       run: |
-        export DEBIAN_FRONTEND=noninteractive
-        apt update -qq
-        apt install -qq -y lsb-release wget curl gnupg2 git
-        cd ..
-        mkdir -p /home/ros2_ws/src
-        cp -r gz_ros2_control /home/ros2_ws/src/
-        curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2$ROS_REPO_PACKAGES/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
         if [ "$GZ_VERSION" == "harmonic" ]; then
           # https://gazebosim.org/docs/harmonic/install_ubuntu/#binary-installation-on-ubuntu
-          curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+          wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-          export GZ_DEPS="gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge ros-humble-ros-gzharmonic-sim"
+          apt-get update && apt-get install --no-install-recommends -qq -y gz-harmonic ros-humble-ros-gzharmonic ros-humble-ros-gzharmonic-bridge ros-humble-ros-gzharmonic-sim
           export GZ_DEPS_ROSDEP="ros_gz ros_gz_bridge ros_gz_sim"
-        fi
-        apt-get update && apt-get upgrade -q -y
-        apt-get update && apt-get install -qq -y \
-          dirmngr \
-          python3-colcon-ros \
-          python3-colcon-common-extensions \
-          python3-rosdep \
-          build-essential \
-          ${GZ_DEPS}
-        cd /home/ros2_ws/src/
-        rosdep init
-        if [ "$GZ_VERSION" == "harmonic" ]; then
           # https://github.com/osrf/osrf-rosdep#installing-rosdep-rules-to-resolve-gazebo-harmonic-libraries
           wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
+        else
+          apt-get update
         fi
         rosdep update --rosdistro humble
         rosdep install --from-paths ./ -i -y --rosdistro humble --skip-keys="${GZ_DEPS_ROSDEP}"
     - name: Build project
       id: build
       run: |
-        cd /home/ros2_ws/
         . /opt/ros/humble/local_setup.sh
         colcon build --packages-up-to gz_ros2_control_demos gz_ros2_control_tests
     - name: Run tests
       id: test
       run: |
-        cd /home/ros2_ws/
         . /opt/ros/humble/local_setup.sh
         colcon test --event-handlers console_direct+ --packages-select gz_ros2_control gz_ros2_control_demos gz_ros2_control_tests
         colcon test-result

--- a/.github/workflows/ci-humble.yaml
+++ b/.github/workflows/ci-humble.yaml
@@ -1,6 +1,7 @@
 name: gz_ros2_control CI - Humble
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ humble ]
   push:

--- a/.github/workflows/ci-humble.yaml
+++ b/.github/workflows/ci-humble.yaml
@@ -5,6 +5,9 @@ on:
     branches: [ humble ]
   push:
     branches: [ humble ]
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '33 5 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
Unsure why this does not fail here but https://github.com/ros-controls/ros2_control_ci/issues/303 did (without the flake8 quote fixes of #558)
but it failed once before https://github.com/ros-controls/gz_ros2_control/actions/runs/14595551059/job/40940456187

I created a separate PR because this here can be "backported" to the other branches to have the same version everywhere.