### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -37,16 +37,15 @@ add_library(${PROJECT_NAME}-system SHARED
 )
 
 target_link_libraries(${PROJECT_NAME}-system
+  PUBLIC
   gz-sim::gz-sim
   gz-plugin::register
-  PUBLIC
-  ament_index_cpp
-  controller_manager
-  hardware_interface
-  pluginlib
-  rclcpp
-  yaml_cpp_vendor
-  rclcpp_lifecycle
+  ament_index_cpp::ament_index_cpp
+  controller_manager::controller_manager
+  hardware_interface::mock_components
+  pluginlib::pluginlib
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 #########
@@ -56,10 +55,10 @@ add_library(gz_hardware_plugins SHARED
 )
 target_link_libraries(gz_hardware_plugins
   gz-sim::gz-sim
-  PUBLIC
-  rclcpp_lifecycle
-  hardware_interface
-  rclcpp
+PUBLIC
+  hardware_interface::mock_components
+  rclcpp::rclcpp
+  rclcpp_lifecycle::rclcpp_lifecycle
 )
 
 ## Install

--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(${PROJECT_NAME}-system
   gz-sim::gz-sim
   gz-plugin::register
 )
-ament_target_dependencies(${PROJECT_NAME}-system
+target_link_libraries(${PROJECT_NAME}-system PUBLIC
   ament_index_cpp
   controller_manager
   hardware_interface
@@ -55,7 +55,7 @@ ament_target_dependencies(${PROJECT_NAME}-system
 add_library(gz_hardware_plugins SHARED
   src/gz_system.cpp
 )
-ament_target_dependencies(gz_hardware_plugins
+target_link_libraries(gz_hardware_plugins PUBLIC
   rclcpp_lifecycle
   hardware_interface
   rclcpp

--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -54,8 +54,8 @@ add_library(gz_hardware_plugins SHARED
   src/gz_system.cpp
 )
 target_link_libraries(gz_hardware_plugins
-  gz-sim::gz-sim
 PUBLIC
+  gz-sim::gz-sim
   hardware_interface::mock_components
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle

--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -39,8 +39,7 @@ add_library(${PROJECT_NAME}-system SHARED
 target_link_libraries(${PROJECT_NAME}-system
   gz-sim::gz-sim
   gz-plugin::register
-)
-target_link_libraries(${PROJECT_NAME}-system PUBLIC
+  PUBLIC
   ament_index_cpp
   controller_manager
   hardware_interface
@@ -55,13 +54,12 @@ target_link_libraries(${PROJECT_NAME}-system PUBLIC
 add_library(gz_hardware_plugins SHARED
   src/gz_system.cpp
 )
-target_link_libraries(gz_hardware_plugins PUBLIC
+target_link_libraries(gz_hardware_plugins
+  gz-sim::gz-sim
+  PUBLIC
   rclcpp_lifecycle
   hardware_interface
   rclcpp
-)
-target_link_libraries(gz_hardware_plugins
-  gz-sim::gz-sim
 )
 
 ## Install

--- a/gz_ros2_control_demos/CMakeLists.txt
+++ b/gz_ros2_control_demos/CMakeLists.txt
@@ -32,37 +32,37 @@ install(DIRECTORY
 
 add_executable(example_position examples/example_position.cpp)
 target_link_libraries(example_position PUBLIC
-  rclcpp
-  rclcpp_action
-  control_msgs
+  ${control_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
 )
 
 # use the same example_position.cpp for example_velocity
 add_executable(example_velocity examples/example_position.cpp)
 target_link_libraries(example_velocity PUBLIC
-  rclcpp
-  rclcpp_action
-  control_msgs
+  ${control_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
 )
 
 # use the same example_position.cpp for example_effort
 add_executable(example_effort examples/example_position.cpp)
 target_link_libraries(example_effort PUBLIC
-  rclcpp
-  rclcpp_action
-  control_msgs
+  ${control_msgs_TARGETS}
+  rclcpp::rclcpp
+  rclcpp_action::rclcpp_action
 )
 
 add_executable(example_mobile_robots examples/example_mobile_robots.cpp)
-target_link_libraries(example_mobile_robots PUBLIC
+ament_target_dependencies(example_mobile_robots
   rclcpp
   geometry_msgs
 )
 
 add_executable(example_gripper examples/example_gripper.cpp)
 target_link_libraries(example_gripper PUBLIC
-  rclcpp
-  std_msgs
+  ${std_msgs_TARGETS}
+  rclcpp::rclcpp
 )
 
 if(BUILD_TESTING)

--- a/gz_ros2_control_demos/CMakeLists.txt
+++ b/gz_ros2_control_demos/CMakeLists.txt
@@ -31,7 +31,7 @@ install(DIRECTORY
 )
 
 add_executable(example_position examples/example_position.cpp)
-ament_target_dependencies(example_position
+target_link_libraries(example_position PUBLIC
   rclcpp
   rclcpp_action
   control_msgs
@@ -39,7 +39,7 @@ ament_target_dependencies(example_position
 
 # use the same example_position.cpp for example_velocity
 add_executable(example_velocity examples/example_position.cpp)
-ament_target_dependencies(example_velocity
+target_link_libraries(example_velocity PUBLIC
   rclcpp
   rclcpp_action
   control_msgs
@@ -47,20 +47,20 @@ ament_target_dependencies(example_velocity
 
 # use the same example_position.cpp for example_effort
 add_executable(example_effort examples/example_position.cpp)
-ament_target_dependencies(example_effort
+target_link_libraries(example_effort PUBLIC
   rclcpp
   rclcpp_action
   control_msgs
 )
 
 add_executable(example_mobile_robots examples/example_mobile_robots.cpp)
-ament_target_dependencies(example_mobile_robots
+target_link_libraries(example_mobile_robots PUBLIC
   rclcpp
   geometry_msgs
 )
 
 add_executable(example_gripper examples/example_gripper.cpp)
-ament_target_dependencies(example_gripper
+target_link_libraries(example_gripper PUBLIC
   rclcpp
   std_msgs
 )


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
