### PR TITLE
Fix ackermann demo

### DIFF
--- a/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
@@ -14,8 +14,8 @@ ackermann_steering_controller:
     traction_wheels_radius: 0.3
     steering_wheels_radius: 0.3
     reference_timeout: 2.0 # In s. Timeout to stop if no cmd_vel is received
-    traction_joints_names: ['rear_left_wheel_joint', 'rear_right_wheel_joint']
-    steering_joints_names: ['left_wheel_steering_joint', 'right_wheel_steering_joint']
+    traction_joints_names: ['rear_right_wheel_joint', 'rear_left_wheel_joint']
+    steering_joints_names: ['right_wheel_steering_joint', 'left_wheel_steering_joint']
     open_loop: false
     velocity_rolling_window_size: 10
     base_frame_id: base_link

--- a/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -109,10 +109,10 @@
   </link>
 
   <joint name="left_wheel_steering_joint" type="revolute">
-    <origin xyz="0.9 -0.5 -0.2" rpy="1.57 0 0" />
+    <origin xyz="0.9 0.5 -0.2" rpy="0 0 0" />
     <parent link="chassis" />
     <child link="left_wheel_steering" />
-    <axis xyz="0 1 0" />
+    <axis xyz="0 0 1" />
     <dynamics damping="0.2" />
     <limit effort="1000.0" lower="-1.57" upper="1.57" velocity="30"/>
   </joint>
@@ -126,10 +126,10 @@
   </link>
 
   <joint name="right_wheel_steering_joint" type="revolute">
-    <origin xyz="0.9 0.5 -0.2" rpy="1.57 0 0" />
+    <origin xyz="0.9 -0.5 -0.2" rpy="0 0 0" />
     <parent link="chassis" />
     <child link="right_wheel_steering" />
-    <axis xyz="0 1 0" />
+    <axis xyz="0 0 1" />
     <dynamics damping="0.2" />
     <limit effort="1000.0" lower="-1.57" upper="1.57" velocity="30"/>
   </joint>
@@ -154,7 +154,7 @@
   </link>
 
   <joint name="front_left_wheel_joint" type="continuous">
-    <origin xyz="0 0 0" rpy="0 0 0" />
+    <origin xyz="0 0 0" rpy="-1.57 0 0" />
     <parent link="left_wheel_steering" />
     <child link="front_left_wheel" />
     <axis xyz="0 0 1" />
@@ -181,7 +181,7 @@
   </link>
 
   <joint name="front_right_wheel_joint" type="continuous">
-    <origin xyz="0 0 0" rpy="0 0 0" />
+    <origin xyz="0 0 0" rpy="-1.57 0 0" />
     <parent link="right_wheel_steering" />
     <child link="front_right_wheel" />
     <axis xyz="0 0 1" />


### PR DESCRIPTION
From issue #438

1. According to the [ros2_controllers documentation](https://control.ros.org/rolling/doc/ros2_controllers/steering_controllers_library/doc/userdoc.html#parameters), the order of joints in `ackermann_drive_controller.yaml` is reversed.
2. The left front wheel and right front wheel are reversed in `test_ackermann_drive.xacro.urdf`.
3. The rotation direction of the front wheels is corrected.

I tested these changes on `humble` branch and the Ackermann vehicle worked well.

---

Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
5. Give your PR a descriptive title. Add a short summary, if required.
6. Make sure the pipeline is green.
7. Don’t be afraid to request reviews from maintainers.
8. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [ ] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
