### PR TITLE
Use ros2_control_cmake

### DIFF
--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -1,14 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(gz_ros2_control)
 
-# Default to C11
-if(NOT CMAKE_C_STANDARD)
-    set(CMAKE_C_STANDARD 11)
-endif()
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
-endif()
+find_package(ros2_control_cmake REQUIRED)
+set_compiler_options()
+export_windows_symbols()
 
 # Compiler options
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/gz_ros2_control/package.xml
+++ b/gz_ros2_control/package.xml
@@ -18,8 +18,10 @@
   <depend>rclcpp</depend>
   <depend>yaml_cpp_vendor</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>hardware_interface</depend>
+
   <depend>controller_manager</depend>
+  <depend>hardware_interface</depend>
+  <depend>ros2_control_cmake</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -292,12 +292,12 @@ void GazeboSimROS2ControlPlugin::Configure(
 
   auto sdfPtr = const_cast<sdf::Element *>(_sdf.get());
 
-  sdf::ElementPtr argument_sdf = sdfPtr->GetElement("parameters");
-  while (argument_sdf) {
-    std::string argument = argument_sdf->Get<std::string>();
+  sdf::ElementPtr argument_sdf_param = sdfPtr->GetElement("parameters");
+  while (argument_sdf_param) {
+    std::string argument = argument_sdf_param->Get<std::string>();
     arguments.push_back(RCL_PARAM_FILE_FLAG);
     arguments.push_back(argument);
-    argument_sdf = argument_sdf->GetNextElement("parameters");
+    argument_sdf_param = argument_sdf_param->GetNextElement("parameters");
   }
 
   // Get controller manager node name
@@ -335,14 +335,14 @@ void GazeboSimROS2ControlPlugin::Configure(
 
     // Get list of remapping rules from SDF
     if (sdfRos->HasElement("remapping")) {
-      sdf::ElementPtr argument_sdf = sdfRos->GetElement("remapping");
+      sdf::ElementPtr argument_sdf_remapping = sdfRos->GetElement("remapping");
 
       arguments.push_back(RCL_ROS_ARGS_FLAG);
-      while (argument_sdf) {
-        std::string argument = argument_sdf->Get<std::string>();
+      while (argument_sdf_remapping) {
+        std::string argument = argument_sdf_remapping->Get<std::string>();
         arguments.push_back(RCL_REMAP_FLAG);
         arguments.push_back(argument);
-        argument_sdf = argument_sdf->GetNextElement("remapping");
+        argument_sdf_remapping = argument_sdf_remapping->GetNextElement("remapping");
       }
     }
   }

--- a/gz_ros2_control_demos/CMakeLists.txt
+++ b/gz_ros2_control_demos/CMakeLists.txt
@@ -1,15 +1,9 @@
 cmake_minimum_required(VERSION 3.5.0)
 project(gz_ros2_control_demos)
 
-# Default to C11
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 11)
-endif()
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
+find_package(ros2_control_cmake REQUIRED)
+set_compiler_options()
+export_windows_symbols()
 
 if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -35,6 +35,7 @@
   <exec_depend>xacro</exec_depend>
 
   <!-- ros2_control -->
+  <depend>ros2_control_cmake</depend>
   <exec_depend>ackermann_steering_controller</exec_depend>
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>
@@ -46,7 +47,7 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>mecanum_drive_controller</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
-  <exec_depend>tricycle_controller</exec_depend>
+  <exec_depend>tricycle_steering_controller</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Needs https://github.com/ros-controls/ros2_control_cmake/pull/7 first

in gz_ros2_control we have `CMAKE_C_STANDARD 11`, was there a reason for a different setup than the official guidelines?

Not sure about CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS, no one ever requested this for windows builds. Maybe it is not even necessary for plugins.