### PR TITLE
Bump CMake minimum version

### DIFF
--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(gz_ros2_control)
 
 find_package(ros2_control_cmake REQUIRED)

--- a/gz_ros2_control_tests/CMakeLists.txt
+++ b/gz_ros2_control_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(gz_ros2_control_tests)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
CMake < 3.10 is deprecated on some platforms https://github.com/ros-controls/ros2_control_cmake/pull/8#pullrequestreview-2904365381