### PR TITLE
Shift to Struct based Method and Constructors, with Executor passed from CM to on_init()

### DIFF
--- a/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
+++ b/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
@@ -39,8 +39,6 @@ class GazeboSimSystem : public GazeboSimSystemInterface
 {
 public:
   // Documentation Inherited
-  CallbackReturn on_init(const hardware_interface::HardwareInfo & system_info)
-  override;
   CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
   override;
 

--- a/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
+++ b/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
@@ -39,6 +39,9 @@ class GazeboSimSystem : public GazeboSimSystemInterface
 {
 public:
   // Documentation Inherited
+  CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+
+  // Documentation Inherited
   CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
   override;
 

--- a/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
+++ b/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
@@ -41,6 +41,8 @@ public:
   // Documentation Inherited
   CallbackReturn on_init(const hardware_interface::HardwareInfo & system_info)
   override;
+  CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
+  override;
 
   CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
 

--- a/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
+++ b/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
@@ -39,6 +39,9 @@ class GazeboSimSystem : public GazeboSimSystemInterface
 {
 public:
   // Documentation Inherited
+  [[deprecated(
+  "Replaced by GazeboSimSystem::on_init(const "
+  "hardware_interface::HardwareComponentInterfaceParams & params).")]]
   CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
 
   // Documentation Inherited

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -76,7 +76,6 @@ public:
     params.update_rate = update_rate;
     params.clock = node_->get_clock();
     params.logger = node_->get_logger();
-    params.executor = node_->get_node_executor_interface();
 
     return load_and_initialize_components(params);
   }
@@ -126,13 +125,13 @@ public:
         logger_, "Initialized robot simulation interface %s!",
         robot_hw_sim_type_str_.c_str());
 
-      hardware_interface::HardwareComponentParams params;
-      params.hardware_info = individual_hardware_info;
-      params.executor = params.executor;
-      params.clock = params.clock;
-      params.logger = params.logger;
+      hardware_interface::HardwareComponentParams component_params;
+      component_params.hardware_info = individual_hardware_info;
+      component_params.executor = params.executor;
+      component_params.clock = params.clock;
+      component_params.logger = params.logger;
       // initialize hardware
-      import_component(std::move(gzSimSystem), params);
+      import_component(std::move(gzSimSystem), component_params);
     }
 
     return components_are_loaded_and_initialized_;

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -71,9 +71,23 @@ public:
     const std::string & urdf,
     unsigned int update_rate) override
   {
+    hardware_interface::ResourceManagerParams params;
+    params.robot_description = urdf;
+    params.update_rate = update_rate;
+    params.clock = node_->get_clock();
+    params.logger = node_->get_logger();
+    params.executor = node_->get_node_executor_interface();
+
+    return load_and_initialize_components(params);
+  }
+
+  bool load_and_initialize_components(
+    const hardware_interface::ResourceManagerParams & params) override
+  {
     components_are_loaded_and_initialized_ = true;
 
-    const auto hardware_info = hardware_interface::parse_control_resources_from_urdf(urdf);
+    const auto hardware_info =
+      hardware_interface::parse_control_resources_from_urdf(params.robot_description);
 
     for (const auto & individual_hardware_info : hardware_info) {
       std::string robot_hw_sim_type_str_ = individual_hardware_info.hardware_plugin_name;
@@ -101,7 +115,7 @@ public:
           enabledJoints_,
           individual_hardware_info,
           *ecm_,
-          update_rate))
+          params.update_rate))
       {
         RCLCPP_FATAL(
           logger_, "Could not initialize robot simulation interface");
@@ -112,8 +126,13 @@ public:
         logger_, "Initialized robot simulation interface %s!",
         robot_hw_sim_type_str_.c_str());
 
+      hardware_interface::HardwareComponentParams params;
+      params.hardware_info = individual_hardware_info;
+      params.executor = params.executor;
+      params.clock = params.clock;
+      params.logger = params.logger;
       // initialize hardware
-      import_component(std::move(gzSimSystem), individual_hardware_info);
+      import_component(std::move(gzSimSystem), params);
     }
 
     return components_are_loaded_and_initialized_;

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -68,19 +68,6 @@ public:
 
   // Called from Controller Manager when robot description is initialized from callback
   bool load_and_initialize_components(
-    const std::string & urdf,
-    unsigned int update_rate) override
-  {
-    hardware_interface::ResourceManagerParams params;
-    params.robot_description = urdf;
-    params.update_rate = update_rate;
-    params.clock = node_->get_clock();
-    params.logger = node_->get_logger();
-
-    return load_and_initialize_components(params);
-  }
-
-  bool load_and_initialize_components(
     const hardware_interface::ResourceManagerParams & params) override
   {
     components_are_loaded_and_initialized_ = true;

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -502,7 +502,10 @@ GazeboSimSystem::on_init(const hardware_interface::HardwareInfo & info)
 CallbackReturn
 GazeboSimSystem::on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  return on_init(params.hardware_info);
+  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
+    return CallbackReturn::ERROR;
+  }
+  return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn GazeboSimSystem::on_configure(

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -490,9 +490,6 @@ void GazeboSimSystem::registerSensors(
     });
 }
 
-[[deprecated(
-  "Replaced by GazeboSimSystem::on_init(const "
-  "hardware_interface::HardwareComponentInterfaceParams & params).")]]
 CallbackReturn
 GazeboSimSystem::on_init(const hardware_interface::HardwareInfo & info)
 {

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -491,18 +491,11 @@ void GazeboSimSystem::registerSensors(
 }
 
 CallbackReturn
-GazeboSimSystem::on_init(const hardware_interface::HardwareInfo & info)
-{
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
-    return CallbackReturn::ERROR;
-  }
-  return CallbackReturn::SUCCESS;
-}
-
-CallbackReturn
 GazeboSimSystem::on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
+  if (hardware_interface::SystemInterface::on_init(params.hardware_info) !=
+    CallbackReturn::SUCCESS)
+  {
     return CallbackReturn::ERROR;
   }
   return CallbackReturn::SUCCESS;

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -490,6 +490,20 @@ void GazeboSimSystem::registerSensors(
     });
 }
 
+[[deprecated(
+  "Replaced by GazeboSimSystem::on_init(const "
+  "hardware_interface::HardwareComponentInterfaceParams & params).")]]
+CallbackReturn
+GazeboSimSystem::on_init(const hardware_interface::HardwareInfo & info)
+{
+  if (hardware_interface::SystemInterface::on_init(info) !=
+    CallbackReturn::SUCCESS)
+  {
+    return CallbackReturn::ERROR;
+  }
+  return CallbackReturn::SUCCESS;
+}
+
 CallbackReturn
 GazeboSimSystem::on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
 {

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -499,6 +499,12 @@ GazeboSimSystem::on_init(const hardware_interface::HardwareInfo & info)
   return CallbackReturn::SUCCESS;
 }
 
+CallbackReturn
+GazeboSimSystem::on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
+{
+  return on_init(params.hardware_info);
+}
+
 CallbackReturn GazeboSimSystem::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -493,7 +493,7 @@ void GazeboSimSystem::registerSensors(
 CallbackReturn
 GazeboSimSystem::on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  if (hardware_interface::SystemInterface::on_init(params.hardware_info) !=
+  if (hardware_interface::SystemInterface::on_init(params) !=
     CallbackReturn::SUCCESS)
   {
     return CallbackReturn::ERROR;


### PR DESCRIPTION
## Brief
This is in reference to API changes done at https://github.com/ros-controls/ros2_control/pull/2323. Refer it for motivation as well as clarity on decisions
- added new params based `on_init` signature  (refer fb9be935187d34d00aad53b869e6bae2fb0b1a47)
- added new params based `load_and_initialize_components` that uses the new `import_components`

Note: Another PR at https://github.com/ros-controls/ros2_control/pull/2340 has the necessary changes for ros2_control to allow complete propagation of params