### PR TITLE
Update pluginlib.xml

### DIFF
--- a/gz_ros2_control/gz_hardware_plugins.xml
+++ b/gz_ros2_control/gz_hardware_plugins.xml
@@ -1,9 +1,5 @@
 <library path="gz_hardware_plugins">
-  <!-- https://docs.ros.org/en/foxy/Tutorials/Beginner-Client-Libraries/Pluginlib.html#plugin-declaration-xml -->
-  <!-- name: There used to be a name attribute, but it is no longer required. -->
-  <!-- TODO(christophfroehlich): remove the name attribute before ROS-K release -->
   <class
-    name="gz_ros2_control/GazeboSimSystem"
     type="gz_ros2_control::GazeboSimSystem"
     base_class_type="gz_ros2_control::GazeboSimSystemInterface">
     <description>

--- a/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -190,7 +190,7 @@
 
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="rear_left_wheel_joint">
       <command_interface name="velocity" />

--- a/gz_ros2_control_demos/urdf/test_cart_effort.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_cart_effort.xacro.urdf
@@ -41,7 +41,7 @@
 
   <ros2_control name="GazeboSimSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="slider_to_cart">
       <command_interface name="effort">

--- a/gz_ros2_control_demos/urdf/test_cart_ft_sensor.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_cart_ft_sensor.xacro.urdf
@@ -53,7 +53,7 @@
 
   <ros2_control name="GazeboSimSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="slider_to_cart">
       <command_interface name="position">

--- a/gz_ros2_control_demos/urdf/test_cart_position.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_cart_position.xacro.urdf
@@ -53,7 +53,7 @@
 
   <ros2_control name="GazeboSimSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="slider_to_cart">
       <command_interface name="position">

--- a/gz_ros2_control_demos/urdf/test_cart_velocity.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_cart_velocity.xacro.urdf
@@ -114,7 +114,7 @@
 
   <ros2_control name="GazeboSimSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="slider_to_cart">
       <command_interface name="velocity">

--- a/gz_ros2_control_demos/urdf/test_diff_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_diff_drive.xacro.urdf
@@ -148,7 +148,7 @@
 
   <ros2_control name="GazeboSimSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="left_wheel_joint">
       <command_interface name="velocity">

--- a/gz_ros2_control_demos/urdf/test_gripper_mimic_joint_effort.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_gripper_mimic_joint_effort.xacro.urdf
@@ -77,7 +77,7 @@
   </joint>
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="right_finger_joint">
       <command_interface name="effort"/>

--- a/gz_ros2_control_demos/urdf/test_gripper_mimic_joint_position.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_gripper_mimic_joint_position.xacro.urdf
@@ -77,7 +77,7 @@
   </joint>
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="right_finger_joint">
       <command_interface name="position"/>

--- a/gz_ros2_control_demos/urdf/test_mecanum_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_mecanum_drive.xacro.urdf
@@ -220,7 +220,7 @@
   <!-- Define the vehicles hardware, command and state interfaces -->
   <ros2_control name="GazeboSimSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="front_left_wheel_joint">
       <command_interface name="velocity">

--- a/gz_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
@@ -77,7 +77,7 @@
 
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="slider_to_cart">
       <command_interface name="effort">

--- a/gz_ros2_control_demos/urdf/test_pendulum_position.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_pendulum_position.xacro.urdf
@@ -77,7 +77,7 @@
 
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="slider_to_cart">
       <command_interface name="position">

--- a/gz_ros2_control_demos/urdf/test_tricycle_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_tricycle_drive.xacro.urdf
@@ -152,7 +152,7 @@
 
   <ros2_control name="GazeboSystem" type="system">
     <hardware>
-      <plugin>gz_ros2_control/GazeboSimSystem</plugin>
+      <plugin>gz_ros2_control::GazeboSimSystem</plugin>
     </hardware>
     <joint name="steering_joint">
       <command_interface name="position" />


### PR DESCRIPTION
https://docs.ros.org/en/foxy/Tutorials/Beginner-Client-Libraries/Pluginlib.html#plugin-declaration-xml
> name: There used to be a name attribute, but it is no longer required.

https://docs.ros.org/en/rolling/Tutorials/Beginner-Client-Libraries/Pluginlib.html
the best practices there seems to be to call the type with `::` as separator of the namespace and plugin. in ros2_control, we generally use `/` -> this is a longer process to switch. 