### PR TITLE
Fix ackermann example inertial and joint tf publish

### DIFF
--- a/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/ackermann_drive_controller.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 10  # Hz
+    update_rate: 100  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -210,6 +210,14 @@
       <command_interface name="position" />
       <state_interface name="position" />
     </joint>
+    <joint name="front_left_wheel_joint">
+      <state_interface name="position" />
+      <state_interface name="velocity" />
+    </joint>
+    <joint name="front_right_wheel_joint">
+      <state_interface name="position" />
+      <state_interface name="velocity" />
+    </joint>
   </ros2_control>
 
   <gazebo>

--- a/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_ackermann_drive.xacro.urdf
@@ -104,7 +104,7 @@
   <link name="left_wheel_steering">
     <inertial>
       <mass value="0.1"/>
-      <inertia ixx="0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0" />
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.002" />
     </inertial>
   </link>
 
@@ -121,7 +121,7 @@
   <link name="right_wheel_steering">
     <inertial>
       <mass value="0.1"/>
-      <inertia ixx="0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0" />
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.002" />
     </inertial>
   </link>
 


### PR DESCRIPTION
# Reproduction of the issue:
## environment:
dev container with rolling base image
gz_ros2_control repo, rolling branch

## steps:
```
ros2 launch gz_ros2_control_demos ackermann_drive_example.launch.py
```

then checking the Robot Model on `/robot_description` topic in rviz2


# Two issues addressed here:

- When opening the robot description topic in rviz2 in a dev container with rolling base image, the following lines print:
```
[ERROR] [1753814980.229868896] [rviz2]: The link left_wheel_steering has unrealistic inertia, so the equivalent inertia box will not be shown.

[ERROR] [1753814980.231523009] [rviz2]: The link right_wheel_steering has unrealistic inertia, so the equivalent inertia box will not be shown.
```


- And the "front_*_wheel_joints" not having any transforms to `base_link`, verifiable via `robot description` in rviz2 and `ros2 run tf2_tools view_frames`:

<img width="1315" height="761" alt="image" src="https://github.com/user-attachments/assets/f4e82427-c623-4492-b9b0-e9b15f50f452" />

