### PR TITLE
Implement reset

### DIFF
--- a/gz_ros2_control/include/gz_ros2_control/gz_ros2_control_plugin.hpp
+++ b/gz_ros2_control/include/gz_ros2_control/gz_ros2_control_plugin.hpp
@@ -29,7 +29,8 @@ class GazeboSimROS2ControlPlugin
   : public sim::System,
   public sim::ISystemConfigure,
   public sim::ISystemPreUpdate,
-  public sim::ISystemPostUpdate
+  public sim::ISystemPostUpdate,
+  public sim::ISystemReset
 {
 public:
   /// \brief Constructor
@@ -53,6 +54,10 @@ public:
   void PostUpdate(
     const sim::UpdateInfo & _info,
     const sim::EntityComponentManager & _ecm) override;
+
+  void Reset(
+    const gz::sim::UpdateInfo & _info,
+    gz::sim::EntityComponentManager & _ecm) override;
 
 private:
   /// \brief Private data pointer.

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -264,6 +264,15 @@ GazeboSimROS2ControlPlugin::~GazeboSimROS2ControlPlugin()
 }
 
 //////////////////////////////////////////////////
+void GazeboSimROS2ControlPlugin::Reset(const gz::sim::UpdateInfo &/*_info*/,
+  gz::sim::EntityComponentManager &/*_ecm*/)
+{
+  RCLCPP_ERROR(
+    this->dataPtr->node_->get_logger(),
+    "Resetting gz_ros2_control plugin");
+}
+
+//////////////////////////////////////////////////
 void GazeboSimROS2ControlPlugin::Configure(
   const sim::Entity & _entity,
   const std::shared_ptr<const sdf::Element> & _sdf,
@@ -540,4 +549,5 @@ GZ_ADD_PLUGIN(
   gz::sim::System,
   gz_ros2_control::GazeboSimROS2ControlPlugin::ISystemConfigure,
   gz_ros2_control::GazeboSimROS2ControlPlugin::ISystemPreUpdate,
+  gz_ros2_control::GazeboSimROS2ControlPlugin::ISystemReset,
   gz_ros2_control::GazeboSimROS2ControlPlugin::ISystemPostUpdate)

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -264,7 +264,8 @@ GazeboSimROS2ControlPlugin::~GazeboSimROS2ControlPlugin()
 }
 
 //////////////////////////////////////////////////
-void GazeboSimROS2ControlPlugin::Reset(const gz::sim::UpdateInfo &/*_info*/,
+void GazeboSimROS2ControlPlugin::Reset(
+  const gz::sim::UpdateInfo &/*_info*/,
   gz::sim::EntityComponentManager &/*_ecm*/)
 {
   RCLCPP_ERROR(


### PR DESCRIPTION
If the model is included in the sdf with the gz_ros2_control plugin and the reset is not implemented, everything is configured again. But Implementing the `reset` method the plugin is still alive and configured