### PR TITLE
Fix compiler warnings

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -171,7 +171,7 @@ public:
 
   /// \brief Last time the update method was called
   rclcpp::Time last_update_sim_time_ros_ =
-    rclcpp::Time((int64_t)0, RCL_ROS_TIME);
+    rclcpp::Time(static_cast<int64_t>(0), RCL_ROS_TIME);
 
   /// \brief ECM pointer
   sim::EntityComponentManager * ecm{nullptr};

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -458,7 +458,8 @@ void GazeboSimROS2ControlPlugin::Configure(
       this->dataPtr->node_->get_namespace(), options));
   this->dataPtr->executor_->add_node(this->dataPtr->controller_manager_);
 
-  this->dataPtr->update_rate = this->dataPtr->controller_manager_->get_update_rate();
+  this->dataPtr->update_rate =
+    static_cast<int>(this->dataPtr->controller_manager_->get_update_rate());
   this->dataPtr->control_period_ = rclcpp::Duration(
     std::chrono::duration_cast<std::chrono::nanoseconds>(
       std::chrono::duration<double>(1.0 / static_cast<double>(this->dataPtr->update_rate))));


### PR DESCRIPTION
```
/workspaces/ros2_rolling_ws/src/gz_ros2_control/gz_ros2_control/src/gz_ros2_control_plugin.cpp:461:68: error: implicit conversion changes signedness: 'unsigned int' to 'int' [-Werror,-Wsign-conversion]
  461 |   this->dataPtr->update_rate = this->dataPtr->controller_manager_->get_update_rate();
      |                              ~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```
```
/workspaces/ros2_rolling_ws/src/gz_ros2_control/gz_ros2_control/src/gz_ros2_control_plugin.cpp:174:18: warning: use of old-style cast [-Wold-style-cast]
  174 |     rclcpp::Time((int64_t)0, RCL_ROS_TIME);
      |                  ^        ~
```
https://github.com/ros-controls/ros2_control_cmake/pull/15