### PR TITLE
Don't call remove_node at destruction

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -254,11 +254,6 @@ GazeboSimROS2ControlPlugin::GazeboSimROS2ControlPlugin()
 //////////////////////////////////////////////////
 GazeboSimROS2ControlPlugin::~GazeboSimROS2ControlPlugin()
 {
-  // Stop controller manager thread
-  if (!this->dataPtr->controller_manager_) {
-    return;
-  }
-  this->dataPtr->executor_->remove_node(this->dataPtr->controller_manager_);
   this->dataPtr->executor_->cancel();
   this->dataPtr->thread_executor_spin_.join();
 }


### PR DESCRIPTION
On humble/harmonic I always  get this stack trace at destruction (CTRL-C in cmd line or closing the GUI)

```
[ign gazebo-1] terminate called after throwing an instance of 'std::runtime_error'
[ign gazebo-1]   what():  Node needs to be associated with an executor.
[ign gazebo-1] Stack trace (most recent call last):
[ign gazebo-1] #31   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7e942a93ec96, in 
[ign gazebo-1] #30   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7e942a93bfc5, in 
[ign gazebo-1] #29   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7e942a939c34, in 
[ign gazebo-1] #28   Object "/usr/lib/x86_64-linux-gnu/ruby/3.0.0/fiddle.so", at 0x7e94269e544b, in 
[ign gazebo-1] #27   Object "/lib/x86_64-linux-gnu/libruby-3.0.so.3.0", at 0x7e942a907088, in rb_nogvl
[ign gazebo-1] #26   Object "/usr/lib/x86_64-linux-gnu/ruby/3.0.0/fiddle.so", at 0x7e94269e4d6b, in 
[ign gazebo-1] #25   Object "/lib/x86_64-linux-gnu/libffi.so.8", at 0x7e9426a13492, in 
[ign gazebo-1] #24   Object "/lib/x86_64-linux-gnu/libffi.so.8", at 0x7e9426a16e2d, in 
[ign gazebo-1] #23   Object "/usr/lib/x86_64-linux-gnu/libignition-gazebo6-ign.so.6.17.0", at 0x7e9425f13e3c, in runServer
[ign gazebo-1] #22   Object "/lib/x86_64-linux-gnu/libignition-gazebo6.so.6", at 0x7e9425af61b4, in ignition::gazebo::v6::Server::~Server()
[ign gazebo-1] #21   Object "/lib/x86_64-linux-gnu/libignition-gazebo6.so.6", at 0x7e9425b02b16, in 
[ign gazebo-1] #20   Object "/lib/x86_64-linux-gnu/libignition-gazebo6.so.6", at 0x7e9425b0f5cc, in ignition::gazebo::v6::SimulationRunner::~SimulationRunner()
[ign gazebo-1] #19   Object "/lib/x86_64-linux-gnu/libignition-gazebo6.so.6", at 0x7e9425b0ea91, in 
[ign gazebo-1] #18   Object "/lib/x86_64-linux-gnu/libignition-gazebo6-gui.so.6", at 0x7e9425d0091c, in ignition::plugin::SpecializedPlugin<ignition::gazebo::v6::System, ignition::gazebo::v6::ISystemConfigure, ignition::gazebo::v6::ISystemPreUpdate, ignition::gazebo::v6::ISystemUpdate, ignition::gazebo::v6::ISystemPostUpdate>::~SpecializedPlugin()
[ign gazebo-1] #17   Object "/lib/x86_64-linux-gnu/libignition-plugin1.so.1", at 0x7e94269c75ec, in ignition::plugin::Plugin::~Plugin()
[ign gazebo-1] #16   Object "/lib/x86_64-linux-gnu/libignition-plugin1.so.1", at 0x7e94269c71d0, in 
[ign gazebo-1] #15   Object "/workspaces/ros2_humble_ws/install/gz_ros2_control/lib/libgz_ros2_control-system.so", at 0x7e93f2feedd3, in std::_Function_handler<void (void*), ignition::plugin::detail::Registrar<gz_ros2_control::GazeboSimROS2ControlPlugin, ignition::gazebo::v6::System, ignition::gazebo::v6::ISystemConfigure, ignition::gazebo::v6::ISystemPreUpdate, ignition::gazebo::v6::ISystemPostUpdate>::MakeInfo()::{lambda(void*)#2}>::_M_invoke(std::_Any_data const&, void*&&)
[ign gazebo-1] #14   Object "/workspaces/ros2_humble_ws/install/gz_ros2_control/lib/libgz_ros2_control-system.so", at 0x7e93f2ff84b0, in std::enable_if<is_invocable_r_v<void, ignition::plugin::detail::Registrar<gz_ros2_control::GazeboSimROS2ControlPlugin, ignition::gazebo::v6::System, ignition::gazebo::v6::ISystemConfigure, ignition::gazebo::v6::ISystemPreUpdate, ignition::gazebo::v6::ISystemPostUpdate>::MakeInfo()::{lambda(void*)#2}&, void*>, void>::type std::__invoke_r<void, ignition::plugin::detail::Registrar<gz_ros2_control::GazeboSimROS2ControlPlugin, ignition::gazebo::v6::System, ignition::gazebo::v6::ISystemConfigure, ignition::gazebo::v6::ISystemPreUpdate, ignition::gazebo::v6::ISystemPostUpdate>::MakeInfo()::{lambda(void*)#2}&, void*>(ignition::plugin::detail::Registrar<gz_ros2_control::GazeboSimROS2ControlPlugin, ignition::gazebo::v6::System, ignition::gazebo::v6::ISystemConfigure, ignition::gazebo::v6::ISystemPreUpdate, ignition::gazebo::v6::ISystemPostUpdate>::MakeInfo()::{lambda(void*)#2}&, void*&&)
[ign gazebo-1] #13   Object "/workspaces/ros2_humble_ws/install/gz_ros2_control/lib/libgz_ros2_control-system.so", at 0x7e93f3000659, in void std::__invoke_impl<void, ignition::plugin::detail::Registrar<gz_ros2_control::GazeboSimROS2ControlPlugin, ignition::gazebo::v6::System, ignition::gazebo::v6::ISystemConfigure, ignition::gazebo::v6::ISystemPreUpdate, ignition::gazebo::v6::ISystemPostUpdate>::MakeInfo()::{lambda(void*)#2}&, void*>(std::__invoke_other, ignition::plugin::detail::Registrar<gz_ros2_control::GazeboSimROS2ControlPlugin, ignition::gazebo::v6::System, ignition::gazebo::v6::ISystemConfigure, ignition::gazebo::v6::ISystemPreUpdate, ignition::gazebo::v6::ISystemPostUpdate>::MakeInfo()::{lambda(void*)#2}&, void*&&)
[ign gazebo-1] #12   Object "/workspaces/ros2_humble_ws/install/gz_ros2_control/lib/libgz_ros2_control-system.so", at 0x7e93f2fcbee3, in ignition::plugin::detail::Registrar<gz_ros2_control::GazeboSimROS2ControlPlugin, ignition::gazebo::v6::System, ignition::gazebo::v6::ISystemConfigure, ignition::gazebo::v6::ISystemPreUpdate, ignition::gazebo::v6::ISystemPostUpdate>::MakeInfo()::{lambda(void*)#2}::operator()(void*) const
[ign gazebo-1] #11   Object "/workspaces/ros2_humble_ws/install/gz_ros2_control/lib/libgz_ros2_control-system.so", at 0x7e93f2faff4b, in gz_ros2_control::GazeboSimROS2ControlPlugin::~GazeboSimROS2ControlPlugin()
[ign gazebo-1] #10   Object "/workspaces/ros2_humble_ws/install/gz_ros2_control/lib/libgz_ros2_control-system.so", at 0x7e93f2fafecc, in gz_ros2_control::GazeboSimROS2ControlPlugin::~GazeboSimROS2ControlPlugin()
[ign gazebo-1] #9    Object "/opt/ros/humble/lib/librclcpp.so", at 0x7e93f20d361c, in 
[ign gazebo-1] #8    Object "/lib/x86_64-linux-gnu/libgcc_s.so.1", at 0x7e942677c2dc, in _Unwind_Resume
[ign gazebo-1] #7    Object "/lib/x86_64-linux-gnu/libgcc_s.so.1", at 0x7e942677b883, in 
[ign gazebo-1] #6    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7e9426832958, in __gxx_personality_v0
[ign gazebo-1] #5    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7e94268321e8, in 
[ign gazebo-1] #4    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7e942683320b, in 
[ign gazebo-1] #3    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7e9426827b9d, in 
[ign gazebo-1] #2    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7e942a5077f2, in abort
[ign gazebo-1] #1    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7e942a521475, in raise
[ign gazebo-1] #0    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7e942a5759fc, in pthread_kill
[ign gazebo-1] Aborted (Signal sent by tkill() 49497 1000)
```

After removing the part with `remove_node` it closes cleanly. It this really necessary?