### PR TITLE
Modernize CMakeLists

### DIFF
--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -93,10 +93,8 @@ ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}-system gz_hardware_plugins)
 
 # Export modern CMake targets
-# TODO() do we need HAS_LIBRARY_TARGET?
 ament_export_targets(
   export_${PROJECT_NAME}
-  HAS_LIBRARY_TARGET
 )
 
 ament_export_dependencies(

--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -31,7 +31,6 @@ include_directories(include)
 add_library(${PROJECT_NAME}-system SHARED
   src/gz_ros2_control_plugin.cpp
 )
-# TODO do we need this alias?
 add_library(${PROJECT_NAME}-system::${PROJECT_NAME}-system ALIAS ${PROJECT_NAME}-system)
 
 target_link_libraries(${PROJECT_NAME}-system

--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(controller_manager REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 
 find_package(gz_sim_vendor REQUIRED)

--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -31,6 +31,8 @@ include_directories(include)
 add_library(${PROJECT_NAME}-system SHARED
   src/gz_ros2_control_plugin.cpp
 )
+# TODO do we need this alias?
+add_library(${PROJECT_NAME}-system::${PROJECT_NAME}-system ALIAS ${PROJECT_NAME}-system)
 
 target_link_libraries(${PROJECT_NAME}-system
   PUBLIC
@@ -39,9 +41,13 @@ target_link_libraries(${PROJECT_NAME}-system
   ament_index_cpp::ament_index_cpp
   controller_manager::controller_manager
   hardware_interface::hardware_interface
-  pluginlib::pluginlib
+  ${pluginlib_TARGETS}
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
+)
+target_include_directories(${PROJECT_NAME}-system PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 #########
@@ -57,17 +63,24 @@ PUBLIC
   rclcpp_lifecycle::rclcpp_lifecycle
 )
 
-## Install
+# Install headers
+install(DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+# Install library and export targets
 install(TARGETS
+  ${PROJECT_NAME}-system
   gz_hardware_plugins
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
-install(DIRECTORY
-  include/
-  DESTINATION include
+install(EXPORT export_${PROJECT_NAME}
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION share/${PROJECT_NAME}/cmake
 )
 
 # Testing and linting
@@ -76,12 +89,20 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+# Export old-style CMake variables
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}-system gz_hardware_plugins)
 
-# Install directories
-install(TARGETS ${PROJECT_NAME}-system
-  DESTINATION lib
+# Export modern CMake targets
+# TODO() do we need HAS_LIBRARY_TARGET?
+ament_export_targets(
+  export_${PROJECT_NAME}
+  HAS_LIBRARY_TARGET
+)
+
+ament_export_dependencies(
+    controller_manager
+    hardware_interface
 )
 
 pluginlib_export_plugin_description_file(gz_ros2_control gz_hardware_plugins.xml)

--- a/gz_ros2_control/CMakeLists.txt
+++ b/gz_ros2_control/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(${PROJECT_NAME}-system
   gz-plugin::register
   ament_index_cpp::ament_index_cpp
   controller_manager::controller_manager
-  hardware_interface::mock_components
+  hardware_interface::hardware_interface
   pluginlib::pluginlib
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
@@ -51,7 +51,7 @@ add_library(gz_hardware_plugins SHARED
 target_link_libraries(gz_hardware_plugins
 PUBLIC
   gz-sim::gz-sim
-  hardware_interface::mock_components
+  hardware_interface::hardware_interface
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
 )

--- a/gz_ros2_control/package.xml
+++ b/gz_ros2_control/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
-  <!-- default version to use in official ROS 2 packages is Gazebo Harmonic for ROS 2 Rolling -->
   <depend>gz_sim_vendor</depend>
   <depend>gz_plugin_vendor</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
I updated the CMakeLists file to be in accordance with https://github.com/ros2/ros2_documentation/pull/5894 and pkg create scripts.

Additionally I fixed missing find_package, wrong target_link_libraries targets and fixed the exports for using the base class from other packages for custom plugins.