### PR TITLE
Update documentation for attaching Force Torque sensor to fixed joints in URDF format 

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -163,19 +163,19 @@ It is important to add this as ``reference`` sensor in the ``<gazebo>`` tag in y
 
 .. code-block:: xml
 
-<gazebo reference="attached_joint">
-  <!-- If using 'attached_joint' is of 'fixed' type, 
-  setting preserveFixedJoint' to true will prevent the 
-  links from being lumped together during the URDF to 
-  SDF conversion. Otherwise, it can be omitted. -->
-  <preserveFixedJoint>true</preserveFixedJoint>
-  <sensor name="force_torque_sensor" type="force_torque">
-    <update_rate>10.0</update_rate>
-    <always_on>true</always_on>
-    <visualize>true</visualize>
-    <topic>force_torque_sensor</topic>
-  </sensor>
-</gazebo>
+  <gazebo reference="attached_joint">
+    <!-- If using 'attached_joint' is of 'fixed' type,
+    setting preserveFixedJoint' to true will prevent the
+    links from being lumped together during the URDF to
+    SDF conversion. Otherwise, it can be omitted. -->
+    <preserveFixedJoint>true</preserveFixedJoint>
+    <sensor name="force_torque_sensor" type="force_torque">
+      <update_rate>10.0</update_rate>
+      <always_on>true</always_on>
+      <visualize>true</visualize>
+      <topic>force_torque_sensor</topic>
+    </sensor>
+  </gazebo>
 
 Add the gz_ros2_control plugin
 ==========================================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -164,8 +164,8 @@ It is important to add this as ``reference`` sensor in the ``<gazebo>`` tag in y
 .. code-block:: xml
 
   <gazebo reference="attached_joint">
-    <!-- If using 'attached_joint' is of 'fixed' type,
-    setting preserveFixedJoint' to true will prevent the
+    <!-- If 'attached_joint' is of 'fixed' type,
+    setting 'preserveFixedJoint' to true will prevent the
     links from being lumped together during the URDF to
     SDF conversion. Otherwise, it can be omitted. -->
     <preserveFixedJoint>true</preserveFixedJoint>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -148,6 +148,8 @@ Using force-torque sensors in simulation
 
 To use ``force-torque`` sensors in *gz_ros2_control* you should define its parameters in your URDF or SDF (see the `SDF specification <http://sdformat.org/spec?ver=1.12&elem=sensor#sensor_force_torque>`__)
 
+An example in SDF is shown here:
+
 .. code-block:: xml
 
   <sensor name="force_torque_sensor" type="force_torque">
@@ -157,7 +159,23 @@ To use ``force-torque`` sensors in *gz_ros2_control* you should define its param
     <topic>force_torque_sensor</topic>
   </sensor>
 
-It is important to add this as ``reference`` sensor in the ``<gazebo>`` tag in your URDF file.
+It is important to add this as ``reference`` sensor in the ``<gazebo>`` tag in your URDF file where the reference is the joint you will be attaching the force torque sensor to:
+
+.. code-block:: xml
+
+<gazebo reference="attached_joint">
+  <!-- If using 'attached_joint' is of 'fixed' type, 
+  setting preserveFixedJoint' to true will prevent the 
+  links from being lumped together during the URDF to 
+  SDF conversion. Otherwise, it can be omitted. -->
+  <preserveFixedJoint>true</preserveFixedJoint>
+  <sensor name="force_torque_sensor" type="force_torque">
+    <update_rate>10.0</update_rate>
+    <always_on>true</always_on>
+    <visualize>true</visualize>
+    <topic>force_torque_sensor</topic>
+  </sensor>
+</gazebo>
 
 Add the gz_ros2_control plugin
 ==========================================


### PR DESCRIPTION
This PR updates the documentation for attaching Force Torque sensor to fixed joints in URDF format. The point on setting the `preserveFixedJoint` tag has been highlighted especially because [fixed joints are lumped together during the SDF to URDF conversion process](http://sdformat.org/tutorials?tut=sdformat_urdf_extensions&cat=specification&#fixed-joint-lumping).