### PR TITLE
Adapting to  signature changes of `on_init()` and `load_and_initialize_components()`

### DIFF
--- a/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
+++ b/gz_ros2_control/include/gz_ros2_control/gz_system.hpp
@@ -39,7 +39,7 @@ class GazeboSimSystem : public GazeboSimSystemInterface
 {
 public:
   // Documentation Inherited
-  CallbackReturn on_init(const hardware_interface::HardwareInfo & system_info)
+  CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
   override;
 
   CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -37,6 +37,8 @@
 #include <hardware_interface/resource_manager.hpp>
 #include <hardware_interface/component_parser.hpp>
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
+#include <hardware_interface/types/hardware_component_params.hpp>
+#include <hardware_interface/types/resource_manager_params.hpp>
 
 #include <pluginlib/class_loader.hpp>
 
@@ -68,12 +70,11 @@ public:
 
   // Called from Controller Manager when robot description is initialized from callback
   bool load_and_initialize_components(
-    const std::string & urdf,
-    unsigned int update_rate) override
+    const hardware_interface::ResourceManagerParams & params) override
   {
     components_are_loaded_and_initialized_ = true;
 
-    const auto hardware_info = hardware_interface::parse_control_resources_from_urdf(urdf);
+    const auto hardware_info = hardware_interface::parse_control_resources_from_urdf(params.robot_description);
 
     for (const auto & individual_hardware_info : hardware_info) {
       std::string robot_hw_sim_type_str_ = individual_hardware_info.hardware_plugin_name;
@@ -101,7 +102,7 @@ public:
           enabledJoints_,
           individual_hardware_info,
           *ecm_,
-          update_rate))
+          params.update_rate))
       {
         RCLCPP_FATAL(
           logger_, "Could not initialize robot simulation interface");
@@ -112,8 +113,15 @@ public:
         logger_, "Initialized robot simulation interface %s!",
         robot_hw_sim_type_str_.c_str());
 
-      // initialize hardware
-      import_component(std::move(gzSimSystem), individual_hardware_info);
+      // initialize hardware - create HardwareComponentParams from ResourceManagerParams
+      hardware_interface::HardwareComponentParams component_params;
+      component_params.hardware_info = individual_hardware_info;
+      component_params.logger = params.logger;
+      component_params.clock = params.clock;
+      component_params.node_namespace = params.node_namespace;
+      component_params.executor = params.executor;
+
+      import_component(std::move(gzSimSystem), component_params);
     }
 
     return components_are_loaded_and_initialized_;

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -576,12 +576,12 @@ void GazeboSimSystem::registerSensors(
 }
 
 CallbackReturn
-GazeboSimSystem::on_init(const hardware_interface::HardwareInfo & info)
+GazeboSimSystem::on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
 {
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS) {
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS) {
     return CallbackReturn::ERROR;
   }
-  if (info.hardware_plugin_name.compare("gz_ros2_control/GazeboSimSystem") != 0) {
+  if (params.hardware_info.hardware_plugin_name.compare("gz_ros2_control/GazeboSimSystem") != 0) {
     RCLCPP_WARN(
       this->nh_->get_logger(),
       "The ign_ros2_control plugin got renamed to gz_ros2_control.\n"


### PR DESCRIPTION
-`on_init()` signature changed: `HardwareInfo&` → `HardwareComponentInterfaceParams&`

- `import_component()` now requires `HardwareComponentParams` instead of `HardwareInfo`, so `HardwareComponentParams` was created from `ResourceManagerParams`

