### PR TITLE
Minor code consistency fix

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -483,7 +483,7 @@ void GazeboSimROS2ControlPlugin::PreUpdate(
     rclcpp::Duration gazebo_period(_info.dt);
 
     // Check the period against the simulation period
-    if (this->dataPtr->control_period_ < _info.dt) {
+    if (this->dataPtr->control_period_ < gazebo_period) {
       RCLCPP_ERROR_STREAM(
         this->dataPtr->node_->get_logger(),
         "Desired controller update period (" << this->dataPtr->control_period_.seconds() <<


### PR DESCRIPTION
Very minor touch-up: as `_info.dt` is wrapped in `gazebo_period`, that `gazebo_period` is used everywhere else in this method. There was still an `_info.dt` usage.