### PR TITLE
Fix platform-independent logging in `gz_ros2_control` plugin

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -226,7 +226,7 @@ GazeboSimROS2ControlPluginPrivate::GetEnabledJoints(
           RCLCPP_WARN_STREAM(
             node_->get_logger(),
             "[gz_ros2_control] Joint [" << jointName << "] (Entity=" << jointEntity
-            << " is of unsupported type. Only joints with a single axis are supported."
+                                        << " is of unsupported type. Only joints with a single axis are supported."
           );
           continue;
         }
@@ -235,7 +235,7 @@ GazeboSimROS2ControlPluginPrivate::GetEnabledJoints(
           RCLCPP_WARN_STREAM(
             node_->get_logger(),
             "[gz_ros2_control] Joint [" << jointName << "] (Entity=" << jointEntity
-            << ") is of unknown type."
+                                        << ") is of unknown type."
           );
         }
     }
@@ -269,12 +269,12 @@ void GazeboSimROS2ControlPlugin::Configure(
   // Make sure the controller is attached to a valid model
   const auto model = sim::Model(_entity);
   if (!model.Valid(_ecm)) {
-      RCLCPP_ERROR_STREAM(
-        logger,
-        "[Gazebo ROS 2 Control] Failed to initialize because ["
+    RCLCPP_ERROR_STREAM(
+      logger,
+      "[Gazebo ROS 2 Control] Failed to initialize because ["
         << model.Name(_ecm) << "] (Entity=" << _entity << ") is not a model. "
         << "Please make sure that Gazebo ROS 2 Control is attached to a valid model."
-      );
+    );
     return;
   }
 

--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -212,10 +212,10 @@ GazeboSimROS2ControlPluginPrivate::GetEnabledJoints(
         }
       case sdf::JointType::FIXED:
         {
-          RCLCPP_INFO(
+          RCLCPP_INFO_STREAM(
             node_->get_logger(),
-            "[gz_ros2_control] Fixed joint [%s] (Entity=%lu)] is skipped",
-            jointName.c_str(), jointEntity);
+            "[gz_ros2_control] Fixed joint [" << jointName << "] (Entity=" << jointEntity << ") is skipped"
+          );
           continue;
         }
       case sdf::JointType::REVOLUTE2:
@@ -223,20 +223,20 @@ GazeboSimROS2ControlPluginPrivate::GetEnabledJoints(
       case sdf::JointType::BALL:
       case sdf::JointType::UNIVERSAL:
         {
-          RCLCPP_WARN(
+          RCLCPP_WARN_STREAM(
             node_->get_logger(),
-            "[gz_ros2_control] Joint [%s] (Entity=%lu)] is of unsupported type."
-            " Only joints with a single axis are supported.",
-            jointName.c_str(), jointEntity);
+            "[gz_ros2_control] Joint [" << jointName << "] (Entity=" << jointEntity
+            << " is of unsupported type. Only joints with a single axis are supported."
+          );
           continue;
         }
       default:
         {
-          RCLCPP_WARN(
+          RCLCPP_WARN_STREAM(
             node_->get_logger(),
-            "[gz_ros2_control] Joint [%s] (Entity=%lu)] is of unknown type",
-            jointName.c_str(), jointEntity);
-          continue;
+            "[gz_ros2_control] Joint [" << jointName << "] (Entity=" << jointEntity
+            << ") is of unknown type."
+          );
         }
     }
     output[jointName] = jointEntity;
@@ -269,11 +269,12 @@ void GazeboSimROS2ControlPlugin::Configure(
   // Make sure the controller is attached to a valid model
   const auto model = sim::Model(_entity);
   if (!model.Valid(_ecm)) {
-    RCLCPP_ERROR(
-      logger,
-      "[Gazebo ROS 2 Control] Failed to initialize because [%s] (Entity=%lu)] is not a model."
-      "Please make sure that Gazebo ROS 2 Control is attached to a valid model.",
-      model.Name(_ecm).c_str(), _entity);
+      RCLCPP_ERROR_STREAM(
+        logger,
+        "[Gazebo ROS 2 Control] Failed to initialize because ["
+        << model.Name(_ecm) << "] (Entity=" << _entity << ") is not a model. "
+        << "Please make sure that Gazebo ROS 2 Control is attached to a valid model."
+      );
     return;
   }
 


### PR DESCRIPTION
**PR Description:**  
This PR addresses compilation errors caused by platform-dependent format specifiers (`%lu` vs `%llu`(`macos`)) in the `gz_ros2_control` plugin logging statements.

### Changes:
- Replaced `RCLCPP_INFO` and `RCLCPP_WARN` calls that used `%lu` / `%llu` with `RCLCPP_INFO_STREAM` / `RCLCPP_WARN_STREAM`.
- Ensures platform-independent logging for `model.Name(_ecm)` and other numeric types.
- Maintains consistency across all logging statements in the plugin.