### PR TITLE
docs: fix broken SDF documentation links (#749)

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -121,7 +121,7 @@ include:
 Using mimic joints in simulation
 -----------------------------------------------------------
 
-To use ``mimic`` joints in *gz_ros2_control* you should define its parameters in your URDF or SDF, i.e, set the ``<mimic>`` tag to the mimicked joint (see the `URDF specification <https://wiki.ros.org/urdf/XML/joint>`__ or the `SDF specification <http://sdformat.org/spec?ver=1.11&elem=joint#axis_mimic>`__)
+To use ``mimic`` joints in *gz_ros2_control* you should define its parameters in your URDF or SDF, i.e, set the ``<mimic>`` tag to the mimicked joint (see the `URDF specification <https://wiki.ros.org/urdf/XML/joint>`__ or the `SDF specification <https://sdformat.org/spec/1.11/joint/#axis_mimic>`__)
 
 .. code-block:: xml
 
@@ -146,7 +146,7 @@ The mimic joint must not have command interfaces configured in the ``<ros2_contr
 Using force-torque sensors in simulation
 -----------------------------------------------------------
 
-To use ``force-torque`` sensors in *gz_ros2_control* you should define its parameters in your URDF or SDF (see the `SDF specification <http://sdformat.org/spec?ver=1.12&elem=sensor#sensor_force_torque>`__)
+To use ``force-torque`` sensors in *gz_ros2_control* you should define its parameters in your URDF or SDF (see the `SDF specification <https://sdformat.org/spec/1.12/sensor/#sensor_force_torque>`__)
 
 An example in SDF is shown here:
 


### PR DESCRIPTION
## Description

Fixes two broken links to SDF documentation as reported in #749.

## Changes

- Line 124: Updated `axis_mimic` link to the SDF 1.11 joint specification  
  (`https://sdformat.org/spec/1.11/joint/#axis_mimic`)
- Line 149: Updated `force_torque` sensor link to the SDF 1.12 sensor specification  
  (`https://sdformat.org/spec/1.12/sensor/#sensor_force_torque`)

## Testing

- Verified both links open correctly in a browser
- Pre-commit checks passed

Closes #749
