### PR TITLE
Restore RM initialization wait time to fix non‑deterministic pendulum test (#801)

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -465,7 +465,7 @@ void GazeboSimROS2ControlPlugin::Configure(
     RCLCPP_WARN(
       this->dataPtr->node_->get_logger(),
       "Waiting RM to load and initialize hardware...");
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
   }
 
   this->dataPtr->entity_ = _entity;


### PR DESCRIPTION
**Context**
After PR #789, the pendulum_test introduced in PR #765 started showing clear non‑deterministic behaviour. A full git bisect identified PR #789 as the source of the regression. The issue is caused by the following change in gz_ros2_control_plugin.cpp:

```
cpp
- std::this_thread::sleep_for(std::chrono::microseconds(2000000));  // 2 seconds
+ std::this_thread::sleep_for(std::chrono::milliseconds(200));      // 0.2 seconds
```

Reducing the initialization wait time by a factor of 10 introduces a race condition where the Resource Manager is not fully initialized before simulation starts, leading to inconsistent controller behavior.

**Fix**
Restore the original wait time to ensure proper initialization:

```
cpp
std::this_thread::sleep_for(std::chrono::milliseconds(2000));
```
**Result**
After applying this fix, the test becomes fully deterministic again (20/20 runs).
This PR resolves issue #801 opened by @christophfroehlich 
