### PR TITLE
pendulum_effort_test: use example_effort to match effort controller

### DIFF
--- a/gz_ros2_control_tests/tests/pendulum_effort_test.py
+++ b/gz_ros2_control_tests/tests/pendulum_effort_test.py
@@ -163,7 +163,7 @@ class TestFixture(unittest.TestCase):
         # 4) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
-            executable='example_velocity',
+            executable='example_effort',
             output='screen',
         )
 


### PR DESCRIPTION
The pendulum_effort_test included in PR #765 was executing "example_velocity".
It is now updated to use "example_effort" to match the effort controller.

