### PR TITLE
Update gz_ros2_control.rolling.repos

### DIFF
--- a/gz_ros2_control.rolling.repos
+++ b/gz_ros2_control.rolling.repos
@@ -19,9 +19,9 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
     version: master
-  ros-controls/ros2_control_demos:
+  ros-controls/ros2_controllers:
     type: git
-    url: https://github.com/ros-controls/ros2_control_demos.git
+    url: https://github.com/ros-controls/ros2_controllers.git
     version: master
   ros-controls/ros2_control_cmake:
     type: git


### PR DESCRIPTION
There was a wrong repo in the rolling repos file, the others are fine