### PR TITLE
Add initial_value checks to state interface tests (backport #765 to Humble)

### DIFF
--- a/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
@@ -26,7 +26,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     # Launch Arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default=True)
-
+    gz_args = LaunchConfiguration('gz_args', default='')
     # Get URDF via xacro
     robot_description_content = Command(
         [
@@ -92,7 +92,7 @@ def generate_launch_description():
                 [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
                                        'launch',
                                        'gz_sim.launch.py'])]),
-            launch_arguments=[('gz_args', [' -r -v 1 empty.sdf'])]),
+            launch_arguments=[('gz_args', [gz_args, ' -r -v 1 empty.sdf'])]),
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,

--- a/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
@@ -26,7 +26,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     # Launch Arguments
     use_sim_time = LaunchConfiguration('use_sim_time', default=True)
-
+    gz_args = LaunchConfiguration('gz_args', default='')
     # Get URDF via xacro
     robot_description_content = Command(
         [
@@ -92,7 +92,7 @@ def generate_launch_description():
                 [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
                                        'launch',
                                        'gz_sim.launch.py'])]),
-            launch_arguments=[('gz_args', '--headless-rendering -s -r -v 1 empty.sdf')]),
+            launch_arguments=[('gz_args', [gz_args, ' -r -v 1 empty.sdf'])]),
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,

--- a/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
+++ b/gz_ros2_control_demos/launch/pendulum_example_effort.launch.py
@@ -92,7 +92,7 @@ def generate_launch_description():
                 [PathJoinSubstitution([FindPackageShare('ros_gz_sim'),
                                        'launch',
                                        'gz_sim.launch.py'])]),
-            launch_arguments=[('gz_args', [' -r -v 1 empty.sdf'])]),
+            launch_arguments=[('gz_args', '--headless-rendering -s -r -v 1 empty.sdf')]),
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=gz_spawn_entity,

--- a/gz_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
@@ -92,8 +92,7 @@
     </joint>
     <joint name="cart_to_pendulum">
       <state_interface name="position">
-        <!-- this does not work if no command interface is set -->
-        <!-- <param name="initial_value">1.57</param> -->
+        <param name="initial_value">1.57</param>
       </state_interface>
       <state_interface name="velocity"/>
       <state_interface name="effort"/>

--- a/gz_ros2_control_tests/tests/CMakeLists.txt
+++ b/gz_ros2_control_tests/tests/CMakeLists.txt
@@ -21,3 +21,7 @@ add_launch_test(effort_test.py
 add_launch_test(ft_sensor_test.py
   TIMEOUT 50
 )
+
+add_launch_test(pendulum_effort_test.py
+  TIMEOUT 50
+)

--- a/gz_ros2_control_tests/tests/effort_test.py
+++ b/gz_ros2_control_tests/tests/effort_test.py
@@ -36,8 +36,10 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
+# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -62,9 +64,12 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
+            # check whether the process name matches
             if proc.name() == 'ruby' or 'gz sim' in proc.name():
+                # up to version 9 of gz-sim
                 proc.kill()
             if 'gz-sim' in proc.name():
+                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 

--- a/gz_ros2_control_tests/tests/effort_test.py
+++ b/gz_ros2_control_tests/tests/effort_test.py
@@ -93,6 +93,47 @@ class TestFixture(unittest.TestCase):
             ],
         )
 
+    def test_slider_position(self):
+        """Test initial_value before motion."""
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        # Verify the message exists
+        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+
+        # Verify initial value
+        joint_idx = msg.name.index('slider_to_cart')
+
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+        )
+
+        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+
     def test_arm(self, launch_service, proc_info, proc_output):
 
         # Check if the controllers are running
@@ -109,5 +150,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/effort_test.py
+++ b/gz_ros2_control_tests/tests/effort_test.py
@@ -36,10 +36,8 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
-# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
-    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -64,10 +62,9 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
-            # check whether the process name matches
-            if proc.name() == 'ruby':
+            if proc.name() == 'ruby' or 'gz sim' in proc.name():
                 proc.kill()
-            if 'gz sim' in proc.name():
+            if 'gz-sim' in proc.name():
                 proc.kill()
         rclpy.shutdown()
 
@@ -88,13 +85,13 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
-    def test_slider_position(self):
-        """Test initial_value before motion."""
+    # -------------------------------
+    # Helper: check initial position
+    # -------------------------------
+    def _check_initial_slider_position(self):
         from sensor_msgs.msg import JointState
         msg = None
 
@@ -109,19 +106,16 @@ class TestFixture(unittest.TestCase):
             10
         )
 
-        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
         while msg is None and self.node.get_clock().now().nanoseconds < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
 
         self.node.destroy_subscription(sub)
 
-        # Verify the message exists
         self.assertIsNotNone(msg, 'No joint_state message received')
-        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+        self.assertIn('slider_to_cart', msg.name)
 
-        # Verify initial value
         joint_idx = msg.name.index('slider_to_cart')
-
         expected_initial_value = 1.0
         actual_value = msg.position[joint_idx]
 
@@ -134,12 +128,22 @@ class TestFixture(unittest.TestCase):
 
         print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
+    # -------------------------------
+    # Main test
+    # -------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
-        cnames = ['joint_trajectory_controller', 'joint_state_broadcaster']
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
+        cnames = [
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_effort',

--- a/gz_ros2_control_tests/tests/effort_test.py
+++ b/gz_ros2_control_tests/tests/effort_test.py
@@ -116,7 +116,7 @@ class TestFixture(unittest.TestCase):
         self.node.destroy_subscription(sub)
 
         # Verify the message exists
-        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIsNotNone(msg, 'No joint_state message received')
         self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
 
         # Verify initial value
@@ -129,10 +129,10 @@ class TestFixture(unittest.TestCase):
             actual_value,
             expected_initial_value,
             places=2,
-            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
         )
 
-        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
     def test_arm(self, launch_service, proc_info, proc_output):
 

--- a/gz_ros2_control_tests/tests/effort_test.py
+++ b/gz_ros2_control_tests/tests/effort_test.py
@@ -88,17 +88,65 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
+    # -------------------------------
+    # Helper: check initial position
+    # -------------------------------
+    def _check_initial_slider_position(self):
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        self.assertIsNotNone(msg, 'No joint_state message received')
+        self.assertIn('slider_to_cart', msg.name)
+
+        joint_idx = msg.name.index('slider_to_cart')
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
+        )
+
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
+
+    # -------------------------------
+    # Main test
+    # -------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
-        cnames = ['joint_trajectory_controller', 'joint_state_broadcaster']
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
+        cnames = [
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_effort',
@@ -109,5 +157,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/ft_sensor_test.py
+++ b/gz_ros2_control_tests/tests/ft_sensor_test.py
@@ -36,8 +36,10 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
+# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -62,9 +64,12 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
+            # check whether the process name matches
             if proc.name() == 'ruby' or 'gz sim' in proc.name():
+                # up to version 9 of gz-sim
                 proc.kill()
             if 'gz-sim' in proc.name():
+                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 

--- a/gz_ros2_control_tests/tests/ft_sensor_test.py
+++ b/gz_ros2_control_tests/tests/ft_sensor_test.py
@@ -93,6 +93,47 @@ class TestFixture(unittest.TestCase):
             ],
         )
 
+    def test_slider_position(self):
+        """Test initial_value before motion."""
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        # Verify the message exists
+        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+
+        # Verify initial value
+        joint_idx = msg.name.index('slider_to_cart')
+
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+        )
+
+        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+
     def test_arm(self, launch_service, proc_info, proc_output):
         # Check if the controllers are running
         cnames = [

--- a/gz_ros2_control_tests/tests/ft_sensor_test.py
+++ b/gz_ros2_control_tests/tests/ft_sensor_test.py
@@ -36,10 +36,8 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
-# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
-    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -64,10 +62,9 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
-            # check whether the process name matches
-            if proc.name() == 'ruby':
+            if proc.name() == 'ruby' or 'gz sim' in proc.name():
                 proc.kill()
-            if 'gz sim' in proc.name():
+            if 'gz-sim' in proc.name():
                 proc.kill()
         rclpy.shutdown()
 
@@ -88,13 +85,13 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
-    def test_slider_position(self):
-        """Test initial_value before motion."""
+    # ---------------------------------------------------------
+    # Helper: check initial slider position BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_slider_position(self):
         from sensor_msgs.msg import JointState
         msg = None
 
@@ -109,19 +106,16 @@ class TestFixture(unittest.TestCase):
             10
         )
 
-        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
         while msg is None and self.node.get_clock().now().nanoseconds < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
 
         self.node.destroy_subscription(sub)
 
-        # Verify the message exists
         self.assertIsNotNone(msg, 'No joint_state message received')
-        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+        self.assertIn('slider_to_cart', msg.name)
 
-        # Verify initial value
         joint_idx = msg.name.index('slider_to_cart')
-
         expected_initial_value = 1.0
         actual_value = msg.position[joint_idx]
 
@@ -134,15 +128,23 @@ class TestFixture(unittest.TestCase):
 
         print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
-        # Check if the controllers are running
+
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
         cnames = [
-                  'joint_trajectory_controller',
-                  'joint_state_broadcaster',
-                  'force_torque_sensor_broadcaster'
-                ]
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+            'force_torque_sensor_broadcaster'
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_position',
@@ -153,5 +155,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/ft_sensor_test.py
+++ b/gz_ros2_control_tests/tests/ft_sensor_test.py
@@ -88,20 +88,66 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
+    # ---------------------------------------------------------
+    # Helper: check initial slider position BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_slider_position(self):
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        self.assertIsNotNone(msg, 'No joint_state message received')
+        self.assertIn('slider_to_cart', msg.name)
+
+        joint_idx = msg.name.index('slider_to_cart')
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
+        )
+
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
+
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
-        # Check if the controllers are running
+
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
         cnames = [
-                  'joint_trajectory_controller',
-                  'joint_state_broadcaster',
-                  'force_torque_sensor_broadcaster'
-                ]
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+            'force_torque_sensor_broadcaster'
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_position',
@@ -112,5 +158,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/ft_sensor_test.py
+++ b/gz_ros2_control_tests/tests/ft_sensor_test.py
@@ -116,7 +116,7 @@ class TestFixture(unittest.TestCase):
         self.node.destroy_subscription(sub)
 
         # Verify the message exists
-        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIsNotNone(msg, 'No joint_state message received')
         self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
 
         # Verify initial value
@@ -129,10 +129,10 @@ class TestFixture(unittest.TestCase):
             actual_value,
             expected_initial_value,
             places=2,
-            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
         )
 
-        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
     def test_arm(self, launch_service, proc_info, proc_output):
         # Check if the controllers are running

--- a/gz_ros2_control_tests/tests/pendulum_effort_test.py
+++ b/gz_ros2_control_tests/tests/pendulum_effort_test.py
@@ -103,10 +103,16 @@ class TestFixture(unittest.TestCase):
         )
 
     # ---------------------------------------------------------
-    # Helper: check initial pendulum angle BEFORE any motion
+    # Helper: ensure joint_states is publishing and pendulum joint exists
+    #
+    # Note: # In ROS 2 Jazzy, the initial_value of the pendulum joint is applied
+    # to the Gazebo simulation, but is not immediately  reflected in the
+    # ros2-control state interface. As a result the initial position cannot be
+    # validated reliably through /joint_states at startup.
     # ---------------------------------------------------------
-    def _check_initial_cart_position(self):
+    def _check_joint_state_topic_and_pendulum_joint(self):
         from sensor_msgs.msg import JointState
+
         msg = None
 
         def callback(m):
@@ -129,26 +135,13 @@ class TestFixture(unittest.TestCase):
         self.assertIsNotNone(msg, 'No joint_state message received')
         self.assertIn('cart_to_pendulum', msg.name)
 
-        joint_idx = msg.name.index('cart_to_pendulum')
-        expected_initial_value = 1.57
-        actual_value = msg.position[joint_idx]
-
-        self.assertAlmostEqual(
-            actual_value,
-            expected_initial_value,
-            places=2,
-            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
-        )
-
-        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
-
     # ---------------------------------------------------------
     # Main test
     # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # 1) Check initial position BEFORE any motion
-        self._check_initial_cart_position()
+        # 1) Ensure joint_states is publishing and pendulum joint exists
+        self._check_joint_state_topic_and_pendulum_joint()
 
         # 2) Wait for controller_manager to be ready
         self._wait_for_controller_manager()

--- a/gz_ros2_control_tests/tests/pendulum_effort_test.py
+++ b/gz_ros2_control_tests/tests/pendulum_effort_test.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# Copyright 2025 ros2_control Maintainers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+from controller_manager.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running
+)
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+import launch_testing
+from launch_testing.actions import ReadyToTest
+from launch_testing.util import KeepAliveProc
+from launch_testing_ros import WaitForTopics
+import psutil
+import pytest
+import rclpy
+from rosgraph_msgs.msg import Clock
+
+
+# This function specifies the processes to be run for our test
+@pytest.mark.rostest
+def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
+    proc_env = os.environ.copy()
+    proc_env['PYTHONUNBUFFERED'] = '1'
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory('gz_ros2_control_demos'),
+                'launch/pendulum_example_effort.launch.py',
+            )
+        ),
+        launch_arguments={'gz_args': '--headless-rendering -s'}.items(),
+    )
+
+    return LaunchDescription([launch_include, KeepAliveProc(), ReadyToTest()])
+
+
+class TestFixture(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        for proc in psutil.process_iter():
+            # check whether the process name matches
+            if proc.name() == 'ruby' or 'gz sim' in proc.name():
+                # up to version 9 of gz-sim
+                proc.kill()
+            if 'gz-sim' in proc.name():
+                # from version 10 of gz-sim
+                proc.kill()
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('test_node')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_node_start(self, proc_output):
+        check_node_running(self.node, 'robot_state_publisher')
+
+    def test_clock(self):
+        topic_list = [('/clock', Clock)]
+        with WaitForTopics(topic_list, timeout=10.0):
+            print('/clock is receiving messages!')
+
+    def test_check_if_msgs_published(self):
+        check_if_js_published(
+            '/joint_states',
+            [
+                'slider_to_cart',
+            ],
+        )
+
+    def test_slider_position(self):
+        """Test initial_value before motion."""
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        # Verify the message exists
+        self.assertIsNotNone(msg, 'No joint_state message received')
+        self.assertIn(
+            'cart_to_pendulum',
+            msg.name,
+            "Joint 'cart_to_pendulum' not found in message"
+        )
+
+        # Verify initial value
+        joint_idx = msg.name.index('cart_to_pendulum')
+
+        expected_initial_value = 1.57
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
+        )
+
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
+
+    def test_arm(self, launch_service, proc_info, proc_output):
+
+        # Check if the controllers are running
+        cnames = [
+                'joint_trajectory_controller',
+                'joint_state_broadcaster',
+                'imu_sensor_broadcaster'
+                ]
+        check_controllers_running(self.node, cnames)
+
+        proc_action = Node(
+            package='gz_ros2_control_demos',
+            executable='example_velocity',
+            output='screen',
+        )
+
+        with launch_testing.tools.launch_process(
+            launch_service, proc_action, proc_info, proc_output
+        ):
+            proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/pendulum_effort_test.py
+++ b/gz_ros2_control_tests/tests/pendulum_effort_test.py
@@ -22,6 +22,7 @@ from controller_manager.test_utils import (
     check_if_js_published,
     check_node_running
 )
+from controller_manager_msgs.srv import ListControllers
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -36,10 +37,8 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
-# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
-    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -64,12 +63,9 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
-            # check whether the process name matches
             if proc.name() == 'ruby' or 'gz sim' in proc.name():
-                # up to version 9 of gz-sim
                 proc.kill()
             if 'gz-sim' in proc.name():
-                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 
@@ -78,6 +74,14 @@ class TestFixture(unittest.TestCase):
 
     def tearDown(self):
         self.node.destroy_node()
+
+    def _wait_for_controller_manager(self, timeout=10.0):
+        cli = self.node.create_client(ListControllers, '/controller_manager/list_controllers')
+        end = self.node.get_clock().now().nanoseconds + int(timeout * 1e9)
+
+        while not cli.wait_for_service(timeout_sec=0.1):
+            if self.node.get_clock().now().nanoseconds > end:
+                self.fail('controller_manager service not available in time')
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, 'robot_state_publisher')
@@ -90,13 +94,13 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart', 'cart_to_pendulum'],
         )
 
-    def test_slider_position(self):
-        """Test initial_value before motion."""
+    # ---------------------------------------------------------
+    # Helper: check initial pendulum angle BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_cart_position(self):
         from sensor_msgs.msg import JointState
         msg = None
 
@@ -111,23 +115,16 @@ class TestFixture(unittest.TestCase):
             10
         )
 
-        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
         while msg is None and self.node.get_clock().now().nanoseconds < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
 
         self.node.destroy_subscription(sub)
 
-        # Verify the message exists
         self.assertIsNotNone(msg, 'No joint_state message received')
-        self.assertIn(
-            'cart_to_pendulum',
-            msg.name,
-            "Joint 'cart_to_pendulum' not found in message"
-        )
+        self.assertIn('cart_to_pendulum', msg.name)
 
-        # Verify initial value
         joint_idx = msg.name.index('cart_to_pendulum')
-
         expected_initial_value = 1.57
         actual_value = msg.position[joint_idx]
 
@@ -140,16 +137,25 @@ class TestFixture(unittest.TestCase):
 
         print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_cart_position()
+
+        # 2) Wait for controller_manager to be ready
+        self._wait_for_controller_manager()
+
+        # 3) Check controllers
         cnames = [
-                'joint_trajectory_controller',
-                'joint_state_broadcaster',
-                'imu_sensor_broadcaster'
-                ]
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 4) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_velocity',

--- a/gz_ros2_control_tests/tests/pendulum_effort_test.py
+++ b/gz_ros2_control_tests/tests/pendulum_effort_test.py
@@ -163,7 +163,7 @@ class TestFixture(unittest.TestCase):
         # 4) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
-            executable='example_velocity',
+            executable='example_effort',
             output='screen',
         )
 

--- a/gz_ros2_control_tests/tests/pendulum_effort_test.py
+++ b/gz_ros2_control_tests/tests/pendulum_effort_test.py
@@ -105,7 +105,7 @@ class TestFixture(unittest.TestCase):
     # ---------------------------------------------------------
     # Helper: ensure joint_states is publishing and pendulum joint exists
     #
-    # Note: # In ROS 2 Jazzy, the initial_value of the pendulum joint is applied
+    # Note: # In ROS 2 Humble, the initial_value of the pendulum joint is applied
     # to the Gazebo simulation, but is not immediately  reflected in the
     # ros2-control state interface. As a result the initial position cannot be
     # validated reliably through /joint_states at startup.
@@ -156,7 +156,7 @@ class TestFixture(unittest.TestCase):
         # 4) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
-            executable='example_velocity',
+            executable='example_effort',
             output='screen',
         )
 

--- a/gz_ros2_control_tests/tests/pendulum_effort_test.py
+++ b/gz_ros2_control_tests/tests/pendulum_effort_test.py
@@ -37,8 +37,10 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
+# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -63,9 +65,12 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
+            # check whether the process name matches
             if proc.name() == 'ruby' or 'gz sim' in proc.name():
+                # up to version 9 of gz-sim
                 proc.kill()
             if 'gz-sim' in proc.name():
+                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 

--- a/gz_ros2_control_tests/tests/pendulum_effort_test.py
+++ b/gz_ros2_control_tests/tests/pendulum_effort_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright 2025 ros2_control Maintainers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+from controller_manager.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running
+)
+from controller_manager_msgs.srv import ListControllers
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+import launch_testing
+from launch_testing.actions import ReadyToTest
+from launch_testing.util import KeepAliveProc
+from launch_testing_ros import WaitForTopics
+import psutil
+import pytest
+import rclpy
+from rosgraph_msgs.msg import Clock
+
+
+# This function specifies the processes to be run for our test
+@pytest.mark.rostest
+def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
+    proc_env = os.environ.copy()
+    proc_env['PYTHONUNBUFFERED'] = '1'
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory('gz_ros2_control_demos'),
+                'launch/pendulum_example_effort.launch.py',
+            )
+        ),
+        launch_arguments={'gz_args': '--headless-rendering -s'}.items(),
+    )
+
+    return LaunchDescription([launch_include, KeepAliveProc(), ReadyToTest()])
+
+
+class TestFixture(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        for proc in psutil.process_iter():
+            # check whether the process name matches
+            if proc.name() == 'ruby' or 'gz sim' in proc.name():
+                # up to version 9 of gz-sim
+                proc.kill()
+            if 'gz-sim' in proc.name():
+                # from version 10 of gz-sim
+                proc.kill()
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('test_node')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def _wait_for_controller_manager(self, timeout=10.0):
+        cli = self.node.create_client(ListControllers, '/controller_manager/list_controllers')
+        end = self.node.get_clock().now().nanoseconds + int(timeout * 1e9)
+
+        while not cli.wait_for_service(timeout_sec=0.1):
+            if self.node.get_clock().now().nanoseconds > end:
+                self.fail('controller_manager service not available in time')
+
+    def test_node_start(self, proc_output):
+        check_node_running(self.node, 'robot_state_publisher')
+
+    def test_clock(self):
+        topic_list = [('/clock', Clock)]
+        with WaitForTopics(topic_list, timeout=10.0):
+            print('/clock is receiving messages!')
+
+    def test_check_if_msgs_published(self):
+        check_if_js_published(
+            '/joint_states',
+            ['slider_to_cart', 'cart_to_pendulum'],
+        )
+
+    # ---------------------------------------------------------
+    # Helper: check initial pendulum angle BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_cart_position(self):
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        self.assertIsNotNone(msg, 'No joint_state message received')
+        self.assertIn('cart_to_pendulum', msg.name)
+
+        joint_idx = msg.name.index('cart_to_pendulum')
+        expected_initial_value = 1.57
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
+        )
+
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
+
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
+    def test_arm(self, launch_service, proc_info, proc_output):
+
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_cart_position()
+
+        # 2) Wait for controller_manager to be ready
+        self._wait_for_controller_manager()
+
+        # 3) Check controllers
+        cnames = [
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+        ]
+        check_controllers_running(self.node, cnames)
+
+        # 4) Launch the node that moves the joint
+        proc_action = Node(
+            package='gz_ros2_control_demos',
+            executable='example_velocity',
+            output='screen',
+        )
+
+        with launch_testing.tools.launch_process(
+            launch_service, proc_action, proc_info, proc_output
+        ):
+            proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/position_test.py
+++ b/gz_ros2_control_tests/tests/position_test.py
@@ -36,10 +36,8 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
-# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
-    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -64,10 +62,9 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
-            # check whether the process name matches
-            if proc.name() == 'ruby':
+            if proc.name() == 'ruby' or 'gz sim' in proc.name():
                 proc.kill()
-            if 'gz sim' in proc.name():
+            if 'gz-sim' in proc.name():
                 proc.kill()
         rclpy.shutdown()
 
@@ -88,13 +85,13 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
-    def test_slider_position(self):
-        """Test initial_value before motion."""
+    # ---------------------------------------------------------
+    # Helper: check initial slider position BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_slider_position(self):
         from sensor_msgs.msg import JointState
         msg = None
 
@@ -109,19 +106,16 @@ class TestFixture(unittest.TestCase):
             10
         )
 
-        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
         while msg is None and self.node.get_clock().now().nanoseconds < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
 
         self.node.destroy_subscription(sub)
 
-        # Verify the message exists
         self.assertIsNotNone(msg, 'No joint_state message received')
-        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+        self.assertIn('slider_to_cart', msg.name)
 
-        # Verify initial value
         joint_idx = msg.name.index('slider_to_cart')
-
         expected_initial_value = 1.0
         actual_value = msg.position[joint_idx]
 
@@ -134,12 +128,22 @@ class TestFixture(unittest.TestCase):
 
         print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
-        cnames = ['joint_trajectory_controller', 'joint_state_broadcaster']
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
+        cnames = [
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_position',
@@ -150,5 +154,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/position_test.py
+++ b/gz_ros2_control_tests/tests/position_test.py
@@ -36,8 +36,10 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
+# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -62,9 +64,12 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
+            # check whether the process name matches
             if proc.name() == 'ruby' or 'gz sim' in proc.name():
+                # up to version 9 of gz-sim
                 proc.kill()
             if 'gz-sim' in proc.name():
+                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 

--- a/gz_ros2_control_tests/tests/position_test.py
+++ b/gz_ros2_control_tests/tests/position_test.py
@@ -93,6 +93,47 @@ class TestFixture(unittest.TestCase):
             ],
         )
 
+    def test_slider_position(self):
+        """Test initial_value before motion."""
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        # Verify the message exists
+        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+
+        # Verify initial value
+        joint_idx = msg.name.index('slider_to_cart')
+
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+        )
+
+        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+
     def test_arm(self, launch_service, proc_info, proc_output):
 
         # Check if the controllers are running

--- a/gz_ros2_control_tests/tests/position_test.py
+++ b/gz_ros2_control_tests/tests/position_test.py
@@ -116,7 +116,7 @@ class TestFixture(unittest.TestCase):
         self.node.destroy_subscription(sub)
 
         # Verify the message exists
-        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIsNotNone(msg, 'No joint_state message received')
         self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
 
         # Verify initial value
@@ -129,10 +129,10 @@ class TestFixture(unittest.TestCase):
             actual_value,
             expected_initial_value,
             places=2,
-            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
         )
 
-        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
     def test_arm(self, launch_service, proc_info, proc_output):
 

--- a/gz_ros2_control_tests/tests/position_test.py
+++ b/gz_ros2_control_tests/tests/position_test.py
@@ -88,17 +88,65 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
+    # ---------------------------------------------------------
+    # Helper: check initial slider position BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_slider_position(self):
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        self.assertIsNotNone(msg, 'No joint_state message received')
+        self.assertIn('slider_to_cart', msg.name)
+
+        joint_idx = msg.name.index('slider_to_cart')
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
+        )
+
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
+
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
-        cnames = ['joint_trajectory_controller', 'joint_state_broadcaster']
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
+        cnames = [
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_position',
@@ -109,5 +157,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
+++ b/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
@@ -90,20 +90,65 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
+    # ---------------------------------------------------------
+    # Helper: check initial slider position BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_slider_position(self):
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        self.assertIsNotNone(msg, 'No joint_state message received')
+        self.assertIn('slider_to_cart', msg.name)
+
+        joint_idx = msg.name.index('slider_to_cart')
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
+        )
+
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
+
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
         cnames = [
-                  'joint_trajectory_controller',
-                  'joint_state_broadcaster'
-                ]
+            'joint_trajectory_controller',
+            'joint_state_broadcaster'
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_velocity',
@@ -114,5 +159,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
+++ b/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
@@ -118,7 +118,7 @@ class TestFixture(unittest.TestCase):
         self.node.destroy_subscription(sub)
 
         # Verify the message exists
-        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIsNotNone(msg, 'No joint_state message received')
         self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
 
         # Verify initial value
@@ -131,10 +131,10 @@ class TestFixture(unittest.TestCase):
             actual_value,
             expected_initial_value,
             places=2,
-            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
         )
 
-        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
     def test_arm(self, launch_service, proc_info, proc_output):
 

--- a/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
+++ b/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
@@ -36,8 +36,10 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
+# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -62,9 +64,12 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
+            # check whether the process name matches
             if proc.name() == 'ruby' or 'gz sim' in proc.name():
+                # up to version 9 of gz-sim
                 proc.kill()
             if 'gz-sim' in proc.name():
+                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 

--- a/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
+++ b/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
@@ -36,10 +36,8 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
-# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
-    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -64,12 +62,9 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
-            # check whether the process name matches
             if proc.name() == 'ruby' or 'gz sim' in proc.name():
-                # up to version 9 of gz-sim
                 proc.kill()
             if 'gz-sim' in proc.name():
-                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 
@@ -90,13 +85,13 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
-    def test_slider_position(self):
-        """Test initial_value before motion."""
+    # ---------------------------------------------------------
+    # Helper: check initial slider position BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_slider_position(self):
         from sensor_msgs.msg import JointState
         msg = None
 
@@ -111,19 +106,16 @@ class TestFixture(unittest.TestCase):
             10
         )
 
-        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
         while msg is None and self.node.get_clock().now().nanoseconds < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
 
         self.node.destroy_subscription(sub)
 
-        # Verify the message exists
         self.assertIsNotNone(msg, 'No joint_state message received')
-        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+        self.assertIn('slider_to_cart', msg.name)
 
-        # Verify initial value
         joint_idx = msg.name.index('slider_to_cart')
-
         expected_initial_value = 1.0
         actual_value = msg.position[joint_idx]
 
@@ -136,15 +128,22 @@ class TestFixture(unittest.TestCase):
 
         print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
         cnames = [
-                  'joint_trajectory_controller',
-                  'joint_state_broadcaster'
-                ]
+            'joint_trajectory_controller',
+            'joint_state_broadcaster'
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_velocity',
@@ -155,5 +154,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
+++ b/gz_ros2_control_tests/tests/velocity_custom_plugin_test.py
@@ -95,6 +95,47 @@ class TestFixture(unittest.TestCase):
             ],
         )
 
+    def test_slider_position(self):
+        """Test initial_value before motion."""
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        # Verify the message exists
+        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+
+        # Verify initial value
+        joint_idx = msg.name.index('slider_to_cart')
+
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+        )
+
+        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+
     def test_arm(self, launch_service, proc_info, proc_output):
 
         # Check if the controllers are running

--- a/gz_ros2_control_tests/tests/velocity_test.py
+++ b/gz_ros2_control_tests/tests/velocity_test.py
@@ -55,30 +55,6 @@ def generate_test_description():
     return LaunchDescription([launch_include, KeepAliveProc(), ReadyToTest()])
 
 
-def wait_for_controller(node, controller_name, timeout_sec=10.0):
-    import time
-    from controller_manager_msgs.srv import ListControllers
-
-    client = node.create_client(ListControllers, '/controller_manager/list_controllers')
-    if not client.wait_for_service(timeout_sec=timeout_sec):
-        raise RuntimeError('Service /controller_manager/list_controllers not available')
-
-    end_time = time.time() + timeout_sec
-    while time.time() < end_time:
-        req = ListControllers.Request()
-        future = client.call_async(req)
-        rclpy.spin_until_future_complete(node, future, timeout_sec=1.0)
-        if future.result() is not None:
-            for c in future.result().controller:
-                if c.name == controller_name and c.state == 'active':
-                    node.destroy_client(client)
-                    return
-        time.sleep(0.2)
-
-    node.destroy_client(client)
-    raise RuntimeError(f'Controller {controller_name} not active after {timeout_sec} seconds')
-
-
 class TestFixture(unittest.TestCase):
 
     @classmethod

--- a/gz_ros2_control_tests/tests/velocity_test.py
+++ b/gz_ros2_control_tests/tests/velocity_test.py
@@ -55,6 +55,30 @@ def generate_test_description():
     return LaunchDescription([launch_include, KeepAliveProc(), ReadyToTest()])
 
 
+def wait_for_controller(node, controller_name, timeout_sec=10.0):
+    import time
+    from controller_manager_msgs.srv import ListControllers
+
+    client = node.create_client(ListControllers, '/controller_manager/list_controllers')
+    if not client.wait_for_service(timeout_sec=timeout_sec):
+        raise RuntimeError('Service /controller_manager/list_controllers not available')
+
+    end_time = time.time() + timeout_sec
+    while time.time() < end_time:
+        req = ListControllers.Request()
+        future = client.call_async(req)
+        rclpy.spin_until_future_complete(node, future, timeout_sec=1.0)
+        if future.result() is not None:
+            for c in future.result().controller:
+                if c.name == controller_name and c.state == 'active':
+                    node.destroy_client(client)
+                    return
+        time.sleep(0.2)
+
+    node.destroy_client(client)
+    raise RuntimeError(f'Controller {controller_name} not active after {timeout_sec} seconds')
+
+
 class TestFixture(unittest.TestCase):
 
     @classmethod
@@ -93,6 +117,31 @@ class TestFixture(unittest.TestCase):
             ],
         )
 
+    def test_initial_position(self):
+        # Test initial_value before motion
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        self.assertIsNotNone(msg)
+        self.assertIn('slider_to_cart', msg.name)
+
     def test_arm(self, launch_service, proc_info, proc_output):
 
         # Check if the controllers are running
@@ -101,8 +150,9 @@ class TestFixture(unittest.TestCase):
                   'joint_state_broadcaster',
                   'imu_sensor_broadcaster'
                 ]
+        for cname in cnames:
+            wait_for_controller(self.node, cname, timeout_sec=10.0)
         check_controllers_running(self.node, cnames)
-
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_velocity',

--- a/gz_ros2_control_tests/tests/velocity_test.py
+++ b/gz_ros2_control_tests/tests/velocity_test.py
@@ -36,8 +36,10 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
+# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
+    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
@@ -62,9 +64,12 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
+            # check whether the process name matches
             if proc.name() == 'ruby' or 'gz sim' in proc.name():
+                # up to version 9 of gz-sim
                 proc.kill()
             if 'gz-sim' in proc.name():
+                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 

--- a/gz_ros2_control_tests/tests/velocity_test.py
+++ b/gz_ros2_control_tests/tests/velocity_test.py
@@ -117,8 +117,8 @@ class TestFixture(unittest.TestCase):
             ],
         )
 
-    def test_initial_position(self):
-        # Test initial_value before motion
+    def test_slider_position(self):
+        """Test initial_value before motion."""
         from sensor_msgs.msg import JointState
         msg = None
 
@@ -139,20 +139,35 @@ class TestFixture(unittest.TestCase):
 
         self.node.destroy_subscription(sub)
 
-        self.assertIsNotNone(msg)
-        self.assertIn('slider_to_cart', msg.name)
+        # Verify the message exists
+        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+
+        # Verify initial value
+        joint_idx = msg.name.index('slider_to_cart')
+
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+        )
+
+        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
 
     def test_arm(self, launch_service, proc_info, proc_output):
 
         # Check if the controllers are running
         cnames = [
-                  'joint_trajectory_controller',
-                  'joint_state_broadcaster',
-                  'imu_sensor_broadcaster'
+                'joint_trajectory_controller',
+                'joint_state_broadcaster',
+                'imu_sensor_broadcaster'
                 ]
-        for cname in cnames:
-            wait_for_controller(self.node, cname, timeout_sec=10.0)
         check_controllers_running(self.node, cnames)
+
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_velocity',
@@ -163,5 +178,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/velocity_test.py
+++ b/gz_ros2_control_tests/tests/velocity_test.py
@@ -36,17 +36,15 @@ import rclpy
 from rosgraph_msgs.msg import Clock
 
 
-# This function specifies the processes to be run for our test
 @pytest.mark.rostest
 def generate_test_description():
-    # This is necessary to get unbuffered output from the process under test
     proc_env = os.environ.copy()
     proc_env['PYTHONUNBUFFERED'] = '1'
     launch_include = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
                 get_package_share_directory('gz_ros2_control_demos'),
-                'launch/cart_example_velocity.launch.py',
+                'launch', 'cart_example_velocity.launch.py',
             )
         ),
         launch_arguments={'gz_args': '--headless-rendering -s'}.items(),
@@ -64,10 +62,9 @@ class TestFixture(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         for proc in psutil.process_iter():
-            # check whether the process name matches
-            if proc.name() == 'ruby':
+            if proc.name() == 'ruby' or 'gz sim' in proc.name():
                 proc.kill()
-            if 'gz sim' in proc.name():
+            if 'gz-sim' in proc.name():
                 proc.kill()
         rclpy.shutdown()
 
@@ -88,13 +85,13 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
-    def test_slider_position(self):
-        """Test initial_value before motion."""
+    # ---------------------------------------------------------
+    # Helper: check initial slider position BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_slider_position(self):
         from sensor_msgs.msg import JointState
         msg = None
 
@@ -109,19 +106,16 @@ class TestFixture(unittest.TestCase):
             10
         )
 
-        end_time = self.node.get_clock().now().nanoseconds + int(5e9)
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
         while msg is None and self.node.get_clock().now().nanoseconds < end_time:
             rclpy.spin_once(self.node, timeout_sec=0.1)
 
         self.node.destroy_subscription(sub)
 
-        # Verify the message exists
         self.assertIsNotNone(msg, 'No joint_state message received')
-        self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
+        self.assertIn('slider_to_cart', msg.name)
 
-        # Verify initial value
         joint_idx = msg.name.index('slider_to_cart')
-
         expected_initial_value = 1.0
         actual_value = msg.position[joint_idx]
 
@@ -134,16 +128,23 @@ class TestFixture(unittest.TestCase):
 
         print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
         cnames = [
-                'joint_trajectory_controller',
-                'joint_state_broadcaster',
-                'imu_sensor_broadcaster'
-                ]
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+            'imu_sensor_broadcaster'
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_velocity',

--- a/gz_ros2_control_tests/tests/velocity_test.py
+++ b/gz_ros2_control_tests/tests/velocity_test.py
@@ -46,7 +46,7 @@ def generate_test_description():
         PythonLaunchDescriptionSource(
             os.path.join(
                 get_package_share_directory('gz_ros2_control_demos'),
-                'launch/cart_example_velocity.launch.py',
+                'launch', 'cart_example_velocity.launch.py',
             )
         ),
         launch_arguments={'gz_args': '--headless-rendering -s'}.items(),
@@ -88,21 +88,66 @@ class TestFixture(unittest.TestCase):
     def test_check_if_msgs_published(self):
         check_if_js_published(
             '/joint_states',
-            [
-                'slider_to_cart',
-            ],
+            ['slider_to_cart'],
         )
 
+    # ---------------------------------------------------------
+    # Helper: check initial slider position BEFORE any motion
+    # ---------------------------------------------------------
+    def _check_initial_slider_position(self):
+        from sensor_msgs.msg import JointState
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            msg = m
+
+        sub = self.node.create_subscription(
+            JointState,
+            '/joint_states',
+            callback,
+            10
+        )
+
+        end_time = self.node.get_clock().now().nanoseconds + int(10e9)
+        while msg is None and self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.node.destroy_subscription(sub)
+
+        self.assertIsNotNone(msg, 'No joint_state message received')
+        self.assertIn('slider_to_cart', msg.name)
+
+        joint_idx = msg.name.index('slider_to_cart')
+        expected_initial_value = 1.0
+        actual_value = msg.position[joint_idx]
+
+        self.assertAlmostEqual(
+            actual_value,
+            expected_initial_value,
+            places=2,
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
+        )
+
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
+
+    # ---------------------------------------------------------
+    # Main test
+    # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
-        # Check if the controllers are running
+        # 1) Check initial position BEFORE any motion
+        self._check_initial_slider_position()
+
+        # 2) Check controllers
         cnames = [
-                  'joint_trajectory_controller',
-                  'joint_state_broadcaster',
-                  'imu_sensor_broadcaster'
-                ]
+            'joint_trajectory_controller',
+            'joint_state_broadcaster',
+            'imu_sensor_broadcaster'
+        ]
         check_controllers_running(self.node, cnames)
 
+        # 3) Launch the node that moves the joint
         proc_action = Node(
             package='gz_ros2_control_demos',
             executable='example_velocity',
@@ -113,5 +158,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
-            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
-                                                   allowable_exit_codes=[0])
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=proc_action,
+                allowable_exit_codes=[0]
+            )

--- a/gz_ros2_control_tests/tests/velocity_test.py
+++ b/gz_ros2_control_tests/tests/velocity_test.py
@@ -116,7 +116,7 @@ class TestFixture(unittest.TestCase):
         self.node.destroy_subscription(sub)
 
         # Verify the message exists
-        self.assertIsNotNone(msg, "No joint_state message received")
+        self.assertIsNotNone(msg, 'No joint_state message received')
         self.assertIn('slider_to_cart', msg.name, "Joint 'slider_to_cart' not found in message")
 
         # Verify initial value
@@ -129,10 +129,10 @@ class TestFixture(unittest.TestCase):
             actual_value,
             expected_initial_value,
             places=2,
-            msg=f"Initial position mismatch: expected {expected_initial_value}, got {actual_value}"
+            msg=f'Initial position mismatch: expected {expected_initial_value}, got {actual_value}'
         )
 
-        print(f"Initial value verified: {actual_value} ≈ {expected_initial_value}")
+        print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
     def test_arm(self, launch_service, proc_info, proc_output):
 


### PR DESCRIPTION

This PR backports to Humble the changes from #765 and the fixes applied in the Jazzy backport (#781).

On Humble, joints exposing only state interfaces do apply <initial_value> to the Gazebo simulation, but this value is not immediately reflected in the ros2_control state interface at startup. As a result, the initial position cannot be reliably validated through /joint_states.

This PR updates the tests accordingly, matching the behavior validated in Jazzy:

- Ensure /joint_states publishes correctly
- Confirm that the pendulum joint exists
- Update pendulum_effort_test to use example_effort
- Adjust initial_value checks to reflect Humble behavior
- Align test logic with the fixes introduced in #781

These changes are required because the same test failures observed in Jazzy also occur in Humble, and the fixes applied in #781 are necessary here as well.

All commits were cherry-picked from the Jazzy backport and adapted where needed.
