### PR TITLE
Comment out initial_value in test_pendulum_effort.xacro.urdf

### DIFF
--- a/gz_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_pendulum_effort.xacro.urdf
@@ -92,7 +92,8 @@
     </joint>
     <joint name="cart_to_pendulum">
       <state_interface name="position">
-        <param name="initial_value">1.57</param>
+        <!-- this does not work if no command interface is set -->
+        <!-- <param name="initial_value">1.57</param> -->
       </state_interface>
       <state_interface name="velocity"/>
       <state_interface name="effort"/>


### PR DESCRIPTION
The pendulum initial position check is reliable in Rolling, but not in older distros. The <initial_value> parameter was mistakenly left active in the backports (Jazzy #781, Humble #822 and Kilted #830), even though it does not behave reliably there.

This commit comments it out to avoid suggesting that the feature works in these distros.
