### PR TITLE
Fix controller dependencies

### DIFF
--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -46,6 +46,7 @@
   <exec_depend>ackermann_steering_controller</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>
   <exec_depend>force_torque_sensor_broadcaster</exec_depend>
+  <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>imu_sensor_broadcaster</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>

--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -45,7 +45,6 @@
   <depend>ros2_control_cmake</depend>
   <exec_depend>ackermann_steering_controller</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>
-  <exec_depend>effort_controllers</exec_depend>
   <exec_depend>force_torque_sensor_broadcaster</exec_depend>
   <exec_depend>imu_sensor_broadcaster</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
@@ -53,7 +52,6 @@
   <exec_depend>mecanum_drive_controller</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
   <exec_depend>tricycle_steering_controller</exec_depend>
-  <exec_depend>velocity_controllers</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
We only use JTC or forward_command_controller for the demos, the specializations got removed with https://github.com/ros-controls/ros2_controllers/pull/2016