### PR TITLE
Remove deprecated has_*_limits parameters from diff_drive_controller …

### DIFF
--- a/gz_ros2_control_demos/config/diff_drive_controller.yaml
+++ b/gz_ros2_control_demos/config/diff_drive_controller.yaml
@@ -34,16 +34,12 @@
 
     # Velocity and acceleration limits
     # Whenever a min_* is unspecified, default to -max_*
-    linear.x.has_velocity_limits: true
-    linear.x.has_acceleration_limits: true
     linear.x.max_velocity: 1.0
     linear.x.min_velocity: -1.0
     linear.x.max_acceleration: 1.0
     linear.x.max_jerk: .NAN
     linear.x.min_jerk: .NAN
 
-    angular.z.has_velocity_limits: true
-    angular.z.has_acceleration_limits: true
     angular.z.max_velocity: 1.0
     angular.z.min_velocity: -1.0
     angular.z.max_acceleration: 1.0


### PR DESCRIPTION
## Description

Remove deprecated `has_*_limits` parameters from diff_drive controller configuration.
This PR cleans up the deprecated parameters as requested in the issue.

Fixes #463

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No

### Additional Information
All deprecated `has_*_limits` parameters have been removed.
The controller now uses only the standard limit parameters without deprecation warnings.

## TODOs
- [x] Fork the repository.
- [x] Modify the source.
- [x] Ensure local tests pass.
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request.