### PR TITLE
Use correct tricycle_controller as dependency

### DIFF
--- a/gz_ros2_control_demos/package.xml
+++ b/gz_ros2_control_demos/package.xml
@@ -52,7 +52,7 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>mecanum_drive_controller</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
-  <exec_depend>tricycle_steering_controller</exec_depend>
+  <exec_depend>tricycle_controller</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
As this is used:
https://github.com/ros-controls/gz_ros2_control/blob/f8c09a3ff7c088eecadda106f4e5250ccd547b7b/gz_ros2_control_demos/config/tricycle_drive_controller.yaml#L12

tricycle_steering_controller is not ready yet, see https://github.com/ros-controls/ros2_controllers/pull/1695