### PR TITLE
Use portable Gazebo entity ID formatting

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -214,8 +214,8 @@ GazeboSimROS2ControlPluginPrivate::GetEnabledJoints(
       case sdf::JointType::FIXED:
         {
           RCLCPP_INFO(
-            node_->get_logger(), "[gz_ros2_control] Fixed joint ['%s'] (Entity='%lu') is skipped.",
-            jointName.c_str(), jointEntity);
+            node_->get_logger(), "[gz_ros2_control] Fixed joint ['%s'] (Entity='%llu') is skipped.",
+            jointName.c_str(), static_cast<unsigned long long>(jointEntity));
           continue;
         }
       case sdf::JointType::REVOLUTE2:
@@ -225,9 +225,9 @@ GazeboSimROS2ControlPluginPrivate::GetEnabledJoints(
         {
           RCLCPP_WARN(
             node_->get_logger(),
-            "[gz_ros2_control] Joint ['%s'] (Entity='%lu') is of unsupported type."
+            "[gz_ros2_control] Joint ['%s'] (Entity='%llu') is of unsupported type."
             " Only joints with a single axis are supported.",
-            jointName.c_str(), jointEntity);
+            jointName.c_str(), static_cast<unsigned long long>(jointEntity));
           continue;
         }
       default:


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

This upstreams `patch/ros-rolling-gz-ros2-control.osx.patch`, authored in RoboStack by Daisuke Nishimatsu `<nishimarudai@gmail.com>`.

Gazebo entity IDs are logged with printf-style ROS logging. Casting the entity value to `unsigned long long` and using the matching format specifier keeps the log statements portable across platforms where the entity type is not `unsigned long`.