### PR TITLE
Avoid Windows ERROR macro conflict in gz_system

### DIFF
--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -51,6 +51,10 @@
 #include <hardware_interface/lexical_casts.hpp>
 #include <hardware_interface/types/hardware_interface_type_values.hpp>
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 struct InterfaceData
 {
   /// \brief State interface shared pointer


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-gz-ros2-control.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: Windows headers can define an `ERROR` macro that conflicts with identifiers used by dependencies included from `gz_system.cpp`. Undefining that macro when present avoids the collision without changing behavior on platforms or include orders where `ERROR` is not defined.