### PR TITLE
Enable MSVC math constants for custom demo plugin

### DIFF
--- a/gz_ros2_control_demos/CMakeLists.txt
+++ b/gz_ros2_control_demos/CMakeLists.txt
@@ -86,6 +86,9 @@ PUBLIC
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
 )
+if(MSVC)
+  target_compile_definitions(gz_custom_hardware_plugins PRIVATE _USE_MATH_DEFINES)
+endif()
 
 #########
 


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-gz-ros2-control-demos.win.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: the custom hardware demo plugin uses C math constants that MSVC exposes only when _USE_MATH_DEFINES is defined before including math headers. Defining it for the target on MSVC keeps the demo portable without affecting other toolchains.