### PR TITLE
Fix command mode stop masks

### DIFF
--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -783,18 +783,21 @@ GazeboSimSystem::perform_command_mode_switch(
   const std::vector<std::string> & start_interfaces,
   const std::vector<std::string> & stop_interfaces)
 {
+  constexpr ControlMethod_ kAllControlMethodBits =
+    static_cast<ControlMethod_>(POSITION | VELOCITY | EFFORT);
+
   for (unsigned int j = 0; j < this->dataPtr->joints_.size(); j++) {
     for (const std::string & interface_name : stop_interfaces) {
       // Clear joint control method bits corresponding to stop interfaces
       if (interface_name == this->dataPtr->joints_[j].if_name_position) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(~POSITION);
+          static_cast<ControlMethod_>(kAllControlMethodBits ^ POSITION);
       } else if (interface_name == this->dataPtr->joints_[j].if_name_velocity) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(~VELOCITY);
+          static_cast<ControlMethod_>(kAllControlMethodBits ^ VELOCITY);
       } else if (interface_name == this->dataPtr->joints_[j].if_name_effort) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(~EFFORT);
+          static_cast<ControlMethod_>(kAllControlMethodBits ^ EFFORT);
       }
     }
 

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -788,13 +788,13 @@ GazeboSimSystem::perform_command_mode_switch(
       // Clear joint control method bits corresponding to stop interfaces
       if (interface_name == this->dataPtr->joints_[j].if_name_position) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(VELOCITY & EFFORT);
+          static_cast<ControlMethod_>(VELOCITY | EFFORT);
       } else if (interface_name == this->dataPtr->joints_[j].if_name_velocity) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(POSITION & EFFORT);
+          static_cast<ControlMethod_>(POSITION | EFFORT);
       } else if (interface_name == this->dataPtr->joints_[j].if_name_effort) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(POSITION & VELOCITY);
+          static_cast<ControlMethod_>(POSITION | VELOCITY);
       }
     }
 

--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -788,13 +788,13 @@ GazeboSimSystem::perform_command_mode_switch(
       // Clear joint control method bits corresponding to stop interfaces
       if (interface_name == this->dataPtr->joints_[j].if_name_position) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(VELOCITY | EFFORT);
+          static_cast<ControlMethod_>(~POSITION);
       } else if (interface_name == this->dataPtr->joints_[j].if_name_velocity) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(POSITION | EFFORT);
+          static_cast<ControlMethod_>(~VELOCITY);
       } else if (interface_name == this->dataPtr->joints_[j].if_name_effort) {
         this->dataPtr->joints_[j].joint_control_method &=
-          static_cast<ControlMethod_>(POSITION | VELOCITY);
+          static_cast<ControlMethod_>(~EFFORT);
       }
     }
 


### PR DESCRIPTION
Fixes #307. Corrects the stop-interface bit masks so stopping one command mode preserves the other active modes. Validation: pre-commit passed, and gz_ros2_control compiled successfully against ROS 2 Jazzy. The package-wide cpplint failure is the existing issue #888 in gz_ros2_control_plugin.cpp and is unrelated to this change.