### PR TITLE
Fix portable entity ID logging

### DIFF
--- a/gz_ros2_control/src/gz_ros2_control_plugin.cpp
+++ b/gz_ros2_control/src/gz_ros2_control_plugin.cpp
@@ -213,9 +213,10 @@ GazeboSimROS2ControlPluginPrivate::GetEnabledJoints(
         }
       case sdf::JointType::FIXED:
         {
-          RCLCPP_INFO(
-            node_->get_logger(), "[gz_ros2_control] Fixed joint ['%s'] (Entity='%llu') is skipped.",
-            jointName.c_str(), static_cast<unsigned long long>(jointEntity));
+          RCLCPP_INFO_STREAM(
+            node_->get_logger(),
+            "[gz_ros2_control] Fixed joint ['" << jointName << "'] (Entity='" << jointEntity
+                                               << "') is skipped.");
           continue;
         }
       case sdf::JointType::REVOLUTE2:
@@ -223,11 +224,11 @@ GazeboSimROS2ControlPluginPrivate::GetEnabledJoints(
       case sdf::JointType::BALL:
       case sdf::JointType::UNIVERSAL:
         {
-          RCLCPP_WARN(
+          RCLCPP_WARN_STREAM(
             node_->get_logger(),
-            "[gz_ros2_control] Joint ['%s'] (Entity='%llu') is of unsupported type."
-            " Only joints with a single axis are supported.",
-            jointName.c_str(), static_cast<unsigned long long>(jointEntity));
+            "[gz_ros2_control] Joint ['" << jointName << "'] (Entity='" << jointEntity
+                                         << "') is of unsupported type."
+                                           " Only joints with a single axis are supported.");
           continue;
         }
       default:


### PR DESCRIPTION
Fixes #888. Replaces the printf-style entity ID log statements introduced by #882 with stream logging. This preserves portable entity ID output while removing the unsigned long long casts rejected by ament_cpplint. Validation: pre-commit passed; ros2_control_cmake and gz_ros2_control built successfully against ROS 2 Jazzy; 29 tests passed with 0 failures.