### PR TITLE
docs: fix `position_proportional_gain` formula in the parameter list

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -214,7 +214,10 @@ The *gz_ros2_control* ``<plugin>`` tag also has the following optional child ele
 The following additional parameters can be set via child elements in the URDF/SDF or via ROS parameters in the YAML file above:
 
 * ``<hold_joints>``: if set to true (default), it will hold the joints' position if their interface was not claimed, e.g., the controller hasn't been activated yet.
-* ``<position_proportional_gain>``: Set the proportional gain. (default: 0.1) This determines the setpoint for a position-controlled joint ``joint_velocity = joint_position_error * position_proportional_gain``.
+* ``<position_proportional_gain>``: Set the proportional gain used by the position command interface. (default: 0.1) It determines the joint velocity setpoint as
+  ``joint_velocity = position_proportional_gain * joint_position_error * controller_manager_update_rate``.
+  See `Notes on the command interface`_ for the resulting closed-loop behavior and for the
+  stability bounds on this value.
 
 or via ROS parameters:
 


### PR DESCRIPTION
## Summary

`doc/index.rst` states the position-interface formula twice, and the two do not agree:

**Line 217** (parameter list):
```
joint_velocity = joint_position_error * position_proportional_gain
```

**Line 481** ("Notes on the command interface"):
```
joint_velocity = position_proportional_gain * joint_position_error * controller_manager_update_rate
```

The implementation agrees with line 481 — `gz_ros2_control/src/gz_system.cpp`:

```cpp
// Get error in position
double error = (this->dataPtr->joints_[i].position.state_value - position_cmd) *
  this->dataPtr->update_rate;

// Calculate target velcity
double target_vel = -this->dataPtr->position_proportional_gain_ * error;
```

So line 217 is missing the `controller_manager_update_rate` factor.

## Why it matters

The parameter list is where people land when they are choosing a value for this
parameter — it is the entry documented next to `<hold_joints>` and next to the YAML
snippet. Read on its own, it makes the gain look ~`update_rate` times weaker than it
is, and it gives no hint why the stability bounds further down ("cannot be greater
than 2 … cannot be greater than 1 to avoid oscillations") are what they are. Those
bounds only follow once the `update_rate` factor is in the formula: the per-cycle
position update is `p[n+1] = p[n] + gain * (cmd - p[n])`, which is where `0 < gain < 2`
comes from.

## Change

Correct the formula in the parameter list to match the implementation, and
cross-reference the section that derives the closed-loop behaviour, so the two
places cannot drift apart again.

Docs only — no code or behaviour change.

## Checked against

- `rolling` @ 1d5c264
- Formula verified against `gz_ros2_control/src/gz_system.cpp` on `rolling`; the same
  code is present on `jazzy`, and the same wording is present in `jazzy`'s `doc/index.rst`,
  so this is a backport candidate.
- `doc/index.rst` parses with docutils with no new warnings; the
  `` `Notes on the command interface`_ `` reference resolves.