### PR TITLE
Apply the mimic joint offset in GazeboSimSystem::write

### DIFF
--- a/gz_ros2_control/src/gz_system.cpp
+++ b/gz_ros2_control/src/gz_system.cpp
@@ -899,7 +899,8 @@ hardware_interface::return_type GazeboSimSystem::write(
       this->dataPtr->joints_[mimic_joint.joint_index].sim_joint)->Data()[0];
 
     double position_error =
-      position_mimic_joint - position_mimicked_joint * mimic_joint.multiplier;
+      position_mimic_joint -
+      (position_mimicked_joint * mimic_joint.multiplier + mimic_joint.offset);
 
     double velocity_sp = (-1.0) * position_error * this->dataPtr->update_rate;
 

--- a/gz_ros2_control_demos/urdf/test_gripper_mimic_joint_position.xacro.urdf
+++ b/gz_ros2_control_demos/urdf/test_gripper_mimic_joint_position.xacro.urdf
@@ -68,7 +68,7 @@
     <limit effort="1000.0" lower="0" upper="0.38" velocity="10"/>
   </joint>
   <joint name="left_finger_joint" type="prismatic">
-    <mimic joint="right_finger_joint"/>
+    <mimic joint="right_finger_joint" multiplier="1.0" offset="0.05"/>
     <axis xyz="0 1 0"/>
     <origin xyz="0.0 0.48 1" rpy="0.0 0.0 3.1415926535"/>
     <parent link="base"/>

--- a/gz_ros2_control_tests/tests/gripper_mimic_joint_position_test.py
+++ b/gz_ros2_control_tests/tests/gripper_mimic_joint_position_test.py
@@ -134,12 +134,64 @@ class TestFixture(unittest.TestCase):
         print(f'Initial value verified: {actual_value} ≈ {expected_initial_value}')
 
     # ---------------------------------------------------------
+    # Helper: the follower must satisfy the URDF mimic relationship
+    #         follower = multiplier * driver + offset
+    # ---------------------------------------------------------
+    def _check_mimic_relationship(self):
+        from sensor_msgs.msg import JointState
+        multiplier = 1.0
+        offset = 0.05
+        msg = None
+
+        def callback(m):
+            nonlocal msg
+            if 'right_finger_joint' in m.name and 'left_finger_joint' in m.name:
+                msg = m
+
+        sub = self.node.create_subscription(JointState, '/joint_states', callback, 10)
+
+        # The follower is driven by a velocity proportional to its position error, so it
+        # converges over time. Sample until it settles rather than taking the first message.
+        end_time = self.node.get_clock().now().nanoseconds + int(20e9)
+        settled = None
+        while self.node.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if msg is None:
+                continue
+            driver = msg.position[msg.name.index('right_finger_joint')]
+            follower = msg.position[msg.name.index('left_finger_joint')]
+            if settled is not None and abs(follower - settled) < 1e-4:
+                break
+            settled = follower
+
+        self.node.destroy_subscription(sub)
+
+        self.assertIsNotNone(msg, 'No joint_state message received')
+
+        driver = msg.position[msg.name.index('right_finger_joint')]
+        follower = msg.position[msg.name.index('left_finger_joint')]
+        expected = multiplier * driver + offset
+
+        self.assertAlmostEqual(
+            follower,
+            expected,
+            places=2,
+            msg=(
+                f'mimic offset not applied: follower {follower} != '
+                f'{multiplier} * {driver} + {offset} = {expected}'
+            ),
+        )
+
+    # ---------------------------------------------------------
     # Main test
     # ---------------------------------------------------------
     def test_arm(self, launch_service, proc_info, proc_output):
 
         # 1) Check initial position BEFORE any motion
         self._check_initial_gripper_position()
+
+        # 1b) The follower must honour multiplier and offset from the URDF
+        self._check_mimic_relationship()
 
         # 2) Check controllers
         cnames = [


### PR DESCRIPTION
Fixes #952.

URDF defines a mimic joint as `follower = multiplier * driver + offset`. `MimicJoint::offset` reaches the plugin and is printed at startup (`gz_system.cpp:391`), but the arithmetic that drives the follower never referenced it, so a URDF declaring an offset produced a follower tracking `multiplier * driver` with the offset silently dropped and no warning.

`gazebo_ros2_control`, the sibling plugin in this org, already applies the full form in `gazebo_system.cpp` (lines 511 and 795).

The existing mimic fixtures declare `<mimic joint="..."/>` with no multiplier or offset, so the default offset of zero made this invisible to the test suite. This adds an explicit multiplier and offset to the position gripper fixture and asserts the follower satisfies the URDF relationship once it settles. The follower is driven by a velocity proportional to its position error, so the assertion samples until the position stabilises rather than taking the first `/joint_states` message.

## Verification

Built and run against Gazebo 8.11 on the `jazzy` branch, which carries the same code, using a gripper whose mimic joint declares `offset="0.05"`:

```
before   driver 0.1500   follower 0.1500   expected 0.2000   error -0.0500
after    driver 0.1500   follower 0.2000   expected 0.2000   error  0.0000
```

The error before the change is exactly the dropped offset.

```
colcon test --packages-select gz_ros2_control_tests --ctest-args -R gripper_mimic_joint_position
```

passes with the change and fails without it, with the source change reverted and the test kept:

```
AssertionError: mimic offset not applied: follower 0.1500 != 1.0 * 0.15 + 0.05 = 0.2
```

`gripper_mimic_joint_effort_test` fails in my environment both with and without this change, on `check_controllers_running`, so it looks unrelated to this patch.

## Credit

@omnilink-tech reported this in #952 with the analysis and the one-line patch, and noted they do not open PRs. The diff to `gz_system.cpp` is theirs; I verified it, added the fixture and test coverage, and am submitting it.
